### PR TITLE
Minimal support for PVR Addon API 1.9.7

### DIFF
--- a/pvr.vbox/addon.xml
+++ b/pvr.vbox/addon.xml
@@ -6,7 +6,7 @@
   provider-name="Sam Stenvall">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="1.9.6"/>
+    <import addon="xbmc.pvr" version="1.9.7"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/pvr.vbox/addon.xml
+++ b/pvr.vbox/addon.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vbox"
-  version="1.3.5"
+  version="1.4.0"
   name="VBox TV Gateway PVR Client"
   provider-name="Sam Stenvall">
   <requires>

--- a/pvr.vbox/changelog.txt
+++ b/pvr.vbox/changelog.txt
@@ -1,3 +1,6 @@
+1.4.0
+	- updated to PVR Addon API v1.9.7
+
 1.3.5
 	- updated Language files from Transifex
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -317,7 +317,6 @@ extern "C" {
     pCapabilities->bSupportsChannelScan = false;
     pCapabilities->bSupportsChannelSettings = false;
     pCapabilities->bHandlesDemuxing = false;
-    pCapabilities->bSupportsRecordingFolders = false;
     pCapabilities->bSupportsRecordingPlayCount = false;
     pCapabilities->bSupportsLastPlayedPosition = false;
     pCapabilities->bSupportsRecordingEdl = false;
@@ -483,6 +482,12 @@ extern "C" {
     }
   }
 
+  PVR_ERROR GetTimerTypes(PVR_TIMER_TYPE types[], int *size)
+  {
+    /* TODO: Implement this to get support for the timer features introduced with PVR API 1.9.7 */
+    return PVR_ERROR_NOT_IMPLEMENTED;
+  }
+
   int GetTimersAmount(void)
   {
     return g_vbox->GetTimersAmount();
@@ -490,6 +495,7 @@ extern "C" {
 
   PVR_ERROR GetTimers(ADDON_HANDLE handle)
   {
+    /* TODO: Change implementation to get support for the timer features introduced with PVR API 1.9.7 */
     auto &recordings = g_vbox->GetRecordingsAndTimers();
 
     for (const auto &item : recordings)
@@ -500,6 +506,9 @@ extern "C" {
 
       PVR_TIMER timer;
       memset(&timer, 0, sizeof(PVR_TIMER));
+
+      /* TODO: Implement own timer types to get support for the timer features introduced with PVR API 1.9.7 */
+      timer.iTimerType = PVR_TIMER_TYPE_NONE;
 
       timer.startTime = xmltv::Utilities::XmltvToUnixTime(item->m_startTime);
       timer.endTime = xmltv::Utilities::XmltvToUnixTime(item->m_endTime);
@@ -609,8 +618,9 @@ extern "C" {
     }
   }
 
-  PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete)
+  PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool /*bDeleteScheduled*/)
   {
+    /* TODO: Change implementation to support bDeleteScheduled (introduced with PVR API 1.9.7 */
     if (g_vbox->DeleteRecordingOrTimer(timer.iClientIndex))
       return PVR_ERROR_NO_ERROR;
 


### PR DESCRIPTION
For, J**** PVR Addon API will be bumped to version 1.9.7 to introduce a couple of new features and enhancements for timers (esp. official series recording support). => https://github.com/xbmc/xbmc/pull/7079

This PR will ensure compatibility with and add minimalistic support for PVR addon API 1.9.7. Even if the maintainers of this addon will do nothing except merging this PR and bump the addon version in Kodi, the addon will still be usable in J**** and not loose any functionality compared to Isengard, but it will not profit from the new features. For the latter, every addon maintainer must do the respective changes on his own.