### PR TITLE
Update to PVR addon API v4.0.0

### DIFF
--- a/pvr.vbox/addon.xml.in
+++ b/pvr.vbox/addon.xml.in
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vbox"
-  version="2.1.1"
+  version="2.1.2"
   name="VBox TV Gateway PVR Client"
   provider-name="Sam Stenvall">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="3.0.0"/>
+    <import addon="xbmc.pvr" version="4.0.0"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/pvr.vbox/changelog.txt
+++ b/pvr.vbox/changelog.txt
@@ -1,3 +1,6 @@
+2.1.2
+	- Updated to PVR API v4.0.0
+
 2.1.1
 	- Updated to PVR API v3.0.0 (API 1.9.7 Compatibility mode)
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -618,9 +618,8 @@ extern "C" {
     }
   }
 
-  PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool /*bDeleteScheduled*/)
+  PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete)
   {
-    /* TODO: Change implementation to support bDeleteScheduled (introduced with PVR API 1.9.7 */
     if (g_vbox->DeleteRecordingOrTimer(timer.iClientIndex))
       return PVR_ERROR_NO_ERROR;
 


### PR DESCRIPTION
This PR implements all changes needed to properly support PVR Addon API v4.0.0, including a PVR addon micro version bump.

Details can be found here: https://github.com/xbmc/xbmc/pull/8005