### PR TITLE
Update to PVR addon API v4.1.0

### DIFF
--- a/pvr.vbox/addon.xml.in
+++ b/pvr.vbox/addon.xml.in
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vbox"
-  version="2.1.2"
+  version="2.1.3"
   name="VBox TV Gateway PVR Client"
   provider-name="Sam Stenvall">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="4.0.0"/>
+    <import addon="xbmc.pvr" version="4.1.0"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/pvr.vbox/changelog.txt
+++ b/pvr.vbox/changelog.txt
@@ -1,3 +1,6 @@
+2.1.3
+	- Updated to PVR API v4.1.0
+
 2.1.2
 	- Updated to PVR API v4.0.0
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -674,6 +674,8 @@ extern "C" {
       std::string cast = xmltv::Utilities::ConcatenateStringList(actorNames);
       event.strCast = cast.c_str();
 
+      event.iFlags = EPG_TAG_FLAG_UNDEFINED;
+      
       PVR->TransferEpgEntry(handle, &event);
     }
 


### PR DESCRIPTION
This PR implements all changes needed to properly support PVR Addon API v4.1.0, including a PVR addon micro version bump.

Details can be found here: xbmc/xbmc#8075