### PR TITLE
Slow startup fix and workaround to channel numbering issue

### DIFF
--- a/pvr.vbox/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vbox/resources/language/resource.language.en_gb/strings.po
@@ -70,7 +70,11 @@ msgctxt "#30104"
 msgid "Use channel icons from external XMLTV"
 msgstr ""
 
-#empty strings from id 30105 to 30199
+msgctxt "#30105"
+msgid "Set channel numbers using backend channel order"
+msgstr ""
+
+#empty strings from id 30106 to 30199
 
 msgctxt "#30200"
 msgid "Timeshift"

--- a/pvr.vbox/resources/settings.xml
+++ b/pvr.vbox/resources/settings.xml
@@ -3,7 +3,7 @@
   <category label="30000">
     <setting id="hostname" type="text" label="30001" default="" />
     <setting id="http_port" type="number" option="int" label="30002" default="80" />
-	<setting id="https_port" type="number" option="int" label="30005" default="" />
+    <setting id="https_port" type="number" option="int" label="30005" default="" />
     <setting id="upnp_port" type="number" option="int" label="30003" default="55555" />
     <setting id="connection_timeout" type="number" option="int" label="30004" default="3" />
   </category>
@@ -11,7 +11,7 @@
   <category label="30050">
     <setting id="external_hostname" type="text" label="30001" default="" />
     <setting id="external_http_port" type="number" option="int" label="30002" default="19999" />
-	<setting id="external_https_port" type="number" option="int" label="30005" default="" />
+    <setting id="external_https_port" type="number" option="int" label="30005" default="" />
     <setting id="external_upnp_port" type="number" option="int" label="30003" default="55555" />
     <setting id="external_connection_timeout" type="number" option="int" label="30004" default="10" />
   </category>
@@ -21,6 +21,7 @@
     <setting id="external_xmltv_path" type="file" label="30102" default="" enable="eq(-1,true)" />
     <setting id="prefer_external_xmltv" type="bool" label="30103" default="false" enable="eq(-2,true)" />
     <setting id="use_external_xmltv_icons" type="bool" label="30104" default="false" enable="eq(-3,true)" />
+    <setting id="set_channelid_using_order" type="bool" label="30105" default="false" />
   </category>
   
   <category label="30200">

--- a/src/vbox/Settings.h
+++ b/src/vbox/Settings.h
@@ -85,6 +85,7 @@ namespace vbox {
     std::string m_externalXmltvPath;
     bool m_preferExternalXmltv;
     bool m_useExternalXmltvIcons;
+    bool m_setChannelIdUsingOrder;
     bool m_timeshiftEnabled;
     std::string m_timeshiftBufferPath;
   };

--- a/src/vbox/response/Content.cpp
+++ b/src/vbox/response/Content.cpp
@@ -33,7 +33,7 @@ using namespace vbox::response;
 std::string Content::GetString(const std::string &parameter) const
 {
   const XMLElement *element = GetParameterElement(parameter);
-
+  
   if (element && element->GetText())
     return std::string(element->GetText());
 

--- a/src/vbox/response/Content.cpp
+++ b/src/vbox/response/Content.cpp
@@ -33,7 +33,7 @@ using namespace vbox::response;
 std::string Content::GetString(const std::string &parameter) const
 {
   const XMLElement *element = GetParameterElement(parameter);
-  
+
   if (element && element->GetText())
     return std::string(element->GetText());
 
@@ -121,11 +121,6 @@ ChannelPtr XMLTVResponseContent::CreateChannel(const tinyxml2::XMLElement *xml) 
 
     channel->m_number = compat::stoui(lcnValue);
   }
-
-  // Set icon URL if it exists
-  const char *iconUrl = xml->FirstChildElement("icon")->Attribute("src");
-  if (iconUrl != NULL)
-    channel->m_iconUrl = iconUrl;
 
   // Set radio and encryption status
   channel->m_radio = type == "Radio";


### PR DESCRIPTION
First change: Don't get the icon URL from the vbox, since the vbox sends a URL to an icon on the PNP Port, which leads to timeout errors when kodi tries to fetch this multiple times concurrently, and the plugin can then take several minutes to startup.

Second Change: Added a new option named "Set channel numbers using backend channel
order" when ticked, the addon will use a basic incremental counter to
set the channel numbers rather than use the numbers returned by the vbox
which are completely incorrect.