### PR TITLE
Add support for all product families ("VB", "VJ", "VZ" etc)

### DIFF
--- a/src/vbox/SoftwareVersion.cpp
+++ b/src/vbox/SoftwareVersion.cpp
@@ -36,8 +36,8 @@ SoftwareVersion SoftwareVersion::ParseString(const std::string &string)
   SoftwareVersion version;
   std::string format = "%d.%d.%d";
 
-  if (string.substr(0, 2) == "VB")
-    format = "VB.%d.%d.%d";
+  if (string.substr(0, 1) == "V")
+    format = string.substr(0, 2) + ".%d.%d.%d";
 
   sscanf(string.c_str(), format.c_str(), &version.m_major, &version.m_minor,
     &version.m_revision);


### PR DESCRIPTION
Hi, I'm an R&D software engineer for VBox Comm - that's the company that owns the product that this add-on integrates into Kodi.
SO far the only product family was "VB", which is the reason it's been hard-coded in this function.
Now we have a line of a new product that's being tested right now ("VJ"), and we need the add-on to recognize those devices as well. Other future products will also be in that format ("V"+another capital letter).

Thanks a lot,
Ariel