### PR TITLE
Fixed recording bug for program names with whitespaces

### DIFF
--- a/pvr.vbox/addon.xml.in
+++ b/pvr.vbox/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vbox"
-  version="2.1.8"
+  version="2.1.9"
   name="VBox TV Gateway PVR Client"
   provider-name="Sam Stenvall">
   <requires>

--- a/pvr.vbox/changelog.txt
+++ b/pvr.vbox/changelog.txt
@@ -1,3 +1,6 @@
+2.1.9
+	- Fixed recording bug for program names with whitespaces
+
 2.1.8
 	- Added support for all VBox Comm product families (2 letters, starts with "V")
 

--- a/src/vbox/response/Response.cpp
+++ b/src/vbox/response/Response.cpp
@@ -30,7 +30,7 @@ Response::Response()
 {
   // Some XMLTV files have weird line endings, try to account for that
   m_document = std::unique_ptr<XMLDocument>(
-    new XMLDocument(/*processEntities = */true, tinyxml2::COLLAPSE_WHITESPACE));
+    new XMLDocument(/*processEntities = */true, tinyxml2::PRESERVE_WHITESPACE));
 
   m_error.code = ErrorCode::SUCCESS;
   m_error.description = "";


### PR DESCRIPTION
Here's the request with the squashed comments.
Thanks again