### PR TITLE
Don't add a guide programme if the title is "String format is not supported"

### DIFF
--- a/src/xmltv/Guide.cpp
+++ b/src/xmltv/Guide.cpp
@@ -59,8 +59,9 @@ Guide::Guide(const XMLElement *m_content)
     std::string channelId = Utilities::UrlDecode(element->Attribute("channel"));
     xmltv::ProgrammePtr programme(new Programme(element));
 
-    // Add the programme to the channel's schedule
-    m_schedules[channelId]->AddProgramme(programme);
+    // Add the programme to the channel's schedule only if the title was parsable
+    if (programme->m_title != Programme::STRING_FORMAT_NOT_SUPPORTED)
+      m_schedules[channelId]->AddProgramme(programme);
   }
 }
 

--- a/src/xmltv/Programme.cpp
+++ b/src/xmltv/Programme.cpp
@@ -26,6 +26,8 @@
 using namespace xmltv;
 using namespace tinyxml2;
 
+const std::string Programme::STRING_FORMAT_NOT_SUPPORTED = "String format is not supported";
+
 Programme::Programme(const tinyxml2::XMLElement *xml)
   : m_year(0)
 {

--- a/src/xmltv/Programme.h
+++ b/src/xmltv/Programme.h
@@ -63,6 +63,11 @@ namespace xmltv {
   public:
 
     /**
+     * Title used by programmes where the VBox cannot figure out the character encoding
+     */
+    static const std::string STRING_FORMAT_NOT_SUPPORTED;
+
+    /**
      * Creates a programme from the specified <programme> element
      */
     Programme(const tinyxml2::XMLElement *xml);


### PR DESCRIPTION
This works around a bug in the VBox firmware, fixes #98