### PR TITLE
Don't query channel streaming status in IsRealTimeStream()

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -816,15 +816,10 @@ extern "C" {
   }
   
   bool IsRealTimeStream(void) 
-  { 
-	  ChannelStreamingStatus status;
+  {
 	  const ChannelPtr currentChannel = g_vbox->GetCurrentChannel();
-	  
-	  // return true only if last active exists & is active
-	  if (!currentChannel)
-		  return false;
-	  status = g_vbox->GetChannelStreamingStatus(currentChannel);
-	  return status.m_active;
+
+    return currentChannel != nullptr;
   }
   
   // Management methods


### PR DESCRIPTION
It's enough to just check whether we're playing a channel or not. Fixes the constant buffering and stuttering reported in #138.