### PR TITLE
Added to TV settings (client specific): rescan EPG & sync with addon

### DIFF
--- a/pvr.vbox/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vbox/resources/language/resource.language.en_gb/strings.po
@@ -74,7 +74,15 @@ msgctxt "#30105"
 msgid "Set channel numbers using backend channel order"
 msgstr ""
 
-#empty strings from id 30106 to 30199
+msgctxt "#30106"
+msgid "VBox device rescan of EPG (will take a while)"
+msgstr ""
+
+msgctxt "#30107"
+msgid "Sync EPG"
+msgstr ""
+
+#empty strings from id 30108 to 30199
 
 msgctxt "#30200"
 msgid "Timeshift"

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1013,14 +1013,16 @@ extern "C" {
       {
         XBMC->QueueNotification(ADDON::QUEUE_INFO, "Rescanning EPG, this will take a while");
         g_vbox->StartEPGScan();
+        return PVR_ERROR_NO_ERROR;
       }
       else if (menuhook.iHookId == MENUHOOK_ID_SYNC_EPG)
       {
         XBMC->QueueNotification(ADDON::QUEUE_INFO, "Getting EPG from VBox device");
         g_vbox->SyncEPGNow();
+        return PVR_ERROR_NO_ERROR;
       }
     }
-    return PVR_ERROR_NO_ERROR;
+    return PVR_ERROR_INVALID_PARAMETERS;
   }
 
   // Management methods

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -61,6 +61,8 @@ bool g_useExternalXmltvIcons;
 bool g_setChannelIdUsingOrder;
 bool g_timeshiftEnabled;
 std::string g_timeshiftBufferPath;
+unsigned int MENUHOOK_ID_RESCAN_EPG = 1;
+unsigned int MENUHOOK_ID_SYNC_EPG = 2;
 
 extern "C" {
 
@@ -178,6 +180,21 @@ extern "C" {
           g_timeshiftBuffer = new timeshift::DummyBuffer();
 
         g_timeshiftBuffer->SetReadTimeout(g_vbox->GetConnectionParams().timeout);
+
+        // initializing TV Settings Client Specific menu hooks
+        PVR_MENUHOOK hook;
+
+        memset(&hook, 0, sizeof(PVR_MENUHOOK));
+        hook.iHookId = MENUHOOK_ID_RESCAN_EPG;
+        hook.iLocalizedStringId = 30106;
+        hook.category = PVR_MENUHOOK_SETTING;
+        PVR->AddMenuHook(&hook);
+
+        memset(&hook, 0, sizeof(PVR_MENUHOOK));
+        hook.iHookId = MENUHOOK_ID_SYNC_EPG;
+        hook.iLocalizedStringId = 30107;
+        hook.category = PVR_MENUHOOK_SETTING;
+        PVR->AddMenuHook(&hook);
       }
       catch (FirmwareVersionException &e) {
         XBMC->QueueNotification(ADDON::QUEUE_ERROR, e.what());
@@ -988,9 +1005,26 @@ extern "C" {
     return currentChannel != nullptr;
   }
   
+  PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook, const PVR_MENUHOOK_DATA &item)
+  {
+    if (menuhook.category == PVR_MENUHOOK_SETTING)
+    {
+      if (menuhook.iHookId == MENUHOOK_ID_RESCAN_EPG)
+      {
+        XBMC->QueueNotification(ADDON::QUEUE_INFO, "Rescanning EPG, this will take a while");
+        g_vbox->StartEPGScan();
+      }
+      else if (menuhook.iHookId == MENUHOOK_ID_SYNC_EPG)
+      {
+        XBMC->QueueNotification(ADDON::QUEUE_INFO, "Getting EPG from VBox device");
+        g_vbox->SyncEPGNow();
+      }
+    }
+    return PVR_ERROR_NO_ERROR;
+  }
+
   // Management methods
   PVR_ERROR DialogChannelScan(void) { return PVR_ERROR_NOT_IMPLEMENTED; }
-  PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook, const PVR_MENUHOOK_DATA &item) { return PVR_ERROR_NOT_IMPLEMENTED; }
   PVR_ERROR DeleteChannel(const PVR_CHANNEL &channel) { return PVR_ERROR_NOT_IMPLEMENTED; }
   PVR_ERROR RenameChannel(const PVR_CHANNEL &channel) { return PVR_ERROR_NOT_IMPLEMENTED; }
   PVR_ERROR MoveChannel(const PVR_CHANNEL &channel) { return PVR_ERROR_NOT_IMPLEMENTED; }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1021,8 +1021,9 @@ extern "C" {
         g_vbox->SyncEPGNow();
         return PVR_ERROR_NO_ERROR;
       }
+	  return PVR_ERROR_INVALID_PARAMETERS;
     }
-    return PVR_ERROR_INVALID_PARAMETERS;
+    return PVR_ERROR_NOT_IMPLEMENTED;
   }
 
   // Management methods


### PR DESCRIPTION
Added 2 menu hooks (client specific settings in TV settings):
1. To send a scan EPG command to the VBox device.
2. To sync EPG in addon with VBox device
