### PR TITLE
Changed setting of channel order display (multi-choice instead of flag)

### DIFF
--- a/pvr.vbox/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vbox/resources/language/resource.language.en_gb/strings.po
@@ -71,7 +71,7 @@ msgid "Use channel icons from external XMLTV"
 msgstr ""
 
 msgctxt "#30105"
-msgid "Set channel numbers using backend channel order"
+msgid "Channel numbers set by"
 msgstr ""
 
 msgctxt "#30106"
@@ -82,7 +82,15 @@ msgctxt "#30107"
 msgid "Sync EPG"
 msgstr ""
 
-#empty strings from id 30108 to 30199
+msgctxt "#30108"
+msgid "LCN (Logical Channel Number) from backend"
+msgstr ""
+
+msgctxt "#30109"
+msgid "Channel index in backend"
+msgstr ""
+
+#empty strings from id 30110 to 30199
 
 msgctxt "#30200"
 msgid "Timeshift"

--- a/pvr.vbox/resources/settings.xml
+++ b/pvr.vbox/resources/settings.xml
@@ -21,7 +21,7 @@
     <setting id="external_xmltv_path" type="file" label="30102" default="" enable="eq(-1,true)" />
     <setting id="prefer_external_xmltv" type="bool" label="30103" default="false" enable="eq(-2,true)" />
     <setting id="use_external_xmltv_icons" type="bool" label="30104" default="false" enable="eq(-3,true)" />
-    <setting id="set_channelid_using_order" type="bool" label="30105" default="false" />
+    <setting id="set_channelid_using_order" type="enum" label="30105" lvalues="30108|30109" default="0"/>
   </category>
   
   <category label="30200">

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -58,7 +58,7 @@ bool g_useExternalXmltv;
 std::string g_externalXmltvPath;
 bool g_preferExternalXmltv;
 bool g_useExternalXmltvIcons;
-bool g_setChannelIdUsingOrder;
+ChannelOrder g_setChannelIdUsingOrder;
 bool g_timeshiftEnabled;
 std::string g_timeshiftBufferPath;
 unsigned int MENUHOOK_ID_RESCAN_EPG = 1;
@@ -94,7 +94,7 @@ extern "C" {
     UPDATE_STR(g_externalXmltvPath, "external_xmltv_path", buffer, "");
     UPDATE_INT(g_preferExternalXmltv, "prefer_external_xmltv", false);
     UPDATE_INT(g_useExternalXmltvIcons, "use_external_xmltv_icons", false);
-    UPDATE_INT(g_setChannelIdUsingOrder, "set_channelid_using_order", false);
+    UPDATE_INT(g_setChannelIdUsingOrder, "set_channelid_using_order", CH_ORDER_BY_LCN);
     UPDATE_INT(g_timeshiftEnabled, "timeshift_enabled", false);
     UPDATE_STR(g_timeshiftBufferPath, "timeshift_path", buffer, "");
 
@@ -275,7 +275,7 @@ extern "C" {
     UPDATE_STR("external_xmltv_path", settings.m_externalXmltvPath);
     UPDATE_INT("prefer_external_xmltv", bool, settings.m_preferExternalXmltv);
     UPDATE_INT("use_external_xmltv_icons", bool, settings.m_useExternalXmltvIcons);
-    UPDATE_INT("set_channelid_using_order", bool, settings.m_setChannelIdUsingOrder);
+    UPDATE_INT("set_channelid_using_order", ChannelOrder, settings.m_setChannelIdUsingOrder);
     UPDATE_INT("timeshift_enabled", bool, settings.m_timeshiftEnabled);
     UPDATE_STR("timeshift_path", settings.m_timeshiftBufferPath);
 
@@ -419,8 +419,9 @@ extern "C" {
 
       // Override LCN if backend channel order should be forced
       ++i;
-      if (g_vbox->GetSettings().m_setChannelIdUsingOrder)
+      if (g_vbox->GetSettings().m_setChannelIdUsingOrder == CH_ORDER_BY_INDEX)
         channel.iChannelNumber = i;
+      // default - CH_ORDER_BY_LCN
       else
         channel.iChannelNumber = item->m_number;
 

--- a/src/vbox/Settings.h
+++ b/src/vbox/Settings.h
@@ -25,6 +25,12 @@
 
 namespace vbox {
 
+  enum ChannelOrder
+  {
+    CH_ORDER_BY_LCN = 0,
+    CH_ORDER_BY_INDEX
+  };
+
   /**
    * Represents a set of parameters required to make a connection
    */
@@ -85,7 +91,7 @@ namespace vbox {
     std::string m_externalXmltvPath;
     bool m_preferExternalXmltv;
     bool m_useExternalXmltvIcons;
-    bool m_setChannelIdUsingOrder;
+    ChannelOrder m_setChannelIdUsingOrder;
     bool m_timeshiftEnabled;
     std::string m_timeshiftBufferPath;
   };


### PR DESCRIPTION
Same algorithm, but instead of setting being a flag, it's now an enum, represented (in the settings screen) by strings