### PR TITLE
Added reminders (popup only) to EPG+channels menus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,10 @@ set(VBOX_SOURCES_VBOX
                 src/vbox/GuideChannelMapper.cpp
                 src/vbox/Recording.h
                 src/vbox/Recording.cpp
+                src/vbox/Reminder.h
+                src/vbox/Reminder.cpp
+                src/vbox/ReminderManager.h
+                src/vbox/ReminderManager.cpp
                 src/vbox/SeriesRecording.h
                 src/vbox/SeriesRecording.cpp
                 src/vbox/Settings.h

--- a/pvr.vbox/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vbox/resources/language/resource.language.en_gb/strings.po
@@ -90,7 +90,27 @@ msgctxt "#30109"
 msgid "Channel index in backend"
 msgstr ""
 
-#empty strings from id 30110 to 30199
+msgctxt "#30110"
+msgid "Remind me"
+msgstr ""
+
+msgctxt "#30111"
+msgid "Manual reminder"
+msgstr ""
+
+msgctxt "#30112"
+msgid "Cancel reminder (if exists)"
+msgstr ""
+
+msgctxt "#30113"
+msgid "Cancel all the channel's reminders"
+msgstr ""
+
+msgctxt "#30114"
+msgid "Reminder time (minutes before program starts)"
+msgstr ""
+
+#empty strings from id 30115 to 30199
 
 msgctxt "#30200"
 msgid "Timeshift"

--- a/pvr.vbox/resources/settings.xml
+++ b/pvr.vbox/resources/settings.xml
@@ -22,6 +22,7 @@
     <setting id="prefer_external_xmltv" type="bool" label="30103" default="false" enable="eq(-2,true)" />
     <setting id="use_external_xmltv_icons" type="bool" label="30104" default="false" enable="eq(-3,true)" />
     <setting id="set_channelid_using_order" type="enum" label="30105" lvalues="30108|30109" default="0"/>
+    <setting id="reminder_mins_before_prog" type="number" option="int" label="30114" default="0"/>
   </category>
   
   <category label="30200">

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -37,6 +37,7 @@ using namespace vbox;
 // Initialize helpers
 CHelper_libXBMC_addon *XBMC = NULL;
 CHelper_libXBMC_pvr   *PVR = NULL;
+CHelper_libKODI_guilib  *GUI = NULL;
 
 // Initialize globals
 ADDON_STATUS   g_status = ADDON_STATUS_UNKNOWN;
@@ -59,10 +60,19 @@ std::string g_externalXmltvPath;
 bool g_preferExternalXmltv;
 bool g_useExternalXmltvIcons;
 ChannelOrder g_setChannelIdUsingOrder;
+unsigned int g_remindMinsBeforeProg;
 bool g_timeshiftEnabled;
 std::string g_timeshiftBufferPath;
+
+// settings context menu
 unsigned int MENUHOOK_ID_RESCAN_EPG = 1;
 unsigned int MENUHOOK_ID_SYNC_EPG = 2;
+// EPG context menu
+unsigned int MENUHOOK_ID_EPG_REMINDER = 1;
+unsigned int MENUHOOK_ID_CANCEL_EPG_REMINDER = 2;
+// channels context menu
+unsigned int MENUHOOK_ID_MANUAL_REMINDER = 1;
+unsigned int MENUHOOK_ID_CANCEL_CHANNEL_REMINDER = 2;
 
 extern "C" {
 
@@ -95,6 +105,7 @@ extern "C" {
     UPDATE_INT(g_preferExternalXmltv, "prefer_external_xmltv", false);
     UPDATE_INT(g_useExternalXmltvIcons, "use_external_xmltv_icons", false);
     UPDATE_INT(g_setChannelIdUsingOrder, "set_channelid_using_order", CH_ORDER_BY_LCN);
+    UPDATE_INT(g_remindMinsBeforeProg, "reminder_mins_before_prog", 0);
     UPDATE_INT(g_timeshiftEnabled, "timeshift_enabled", false);
     UPDATE_STR(g_timeshiftBufferPath, "timeshift_path", buffer, "");
 
@@ -110,12 +121,15 @@ extern "C" {
     // Instantiate helpers
     XBMC = new CHelper_libXBMC_addon;
     PVR = new CHelper_libXBMC_pvr;
+    GUI = new CHelper_libKODI_guilib;
 
     if (!XBMC->RegisterMe(hdl) ||
-      !PVR->RegisterMe(hdl))
+      !PVR->RegisterMe(hdl) || 
+      !GUI->RegisterMe(hdl) ) 
     {
       SAFE_DELETE(XBMC);
       SAFE_DELETE(PVR);
+      SAFE_DELETE(GUI);
       return ADDON_STATUS_PERMANENT_FAILURE;
     }
 
@@ -147,6 +161,7 @@ extern "C" {
     settings.m_preferExternalXmltv = g_preferExternalXmltv;
     settings.m_useExternalXmltvIcons = g_useExternalXmltvIcons;
     settings.m_setChannelIdUsingOrder = g_setChannelIdUsingOrder;
+    settings.m_remindMinsBeforeProg = g_remindMinsBeforeProg;
     settings.m_timeshiftEnabled = g_timeshiftEnabled;
     settings.m_timeshiftBufferPath = g_timeshiftBufferPath;
 
@@ -194,6 +209,32 @@ extern "C" {
         hook.iHookId = MENUHOOK_ID_SYNC_EPG;
         hook.iLocalizedStringId = 30107;
         hook.category = PVR_MENUHOOK_SETTING;
+        PVR->AddMenuHook(&hook);
+
+        // initialize EPG context menu
+        memset(&hook, 0, sizeof(PVR_MENUHOOK));
+        hook.iHookId = MENUHOOK_ID_EPG_REMINDER;
+        hook.iLocalizedStringId = 30110;
+        hook.category = PVR_MENUHOOK_EPG;
+        PVR->AddMenuHook(&hook);
+
+        memset(&hook, 0, sizeof(PVR_MENUHOOK));
+        hook.iHookId = MENUHOOK_ID_CANCEL_EPG_REMINDER;
+        hook.iLocalizedStringId = 30112;
+        hook.category = PVR_MENUHOOK_EPG;
+        PVR->AddMenuHook(&hook);
+
+        // initialize channels context menu
+        memset(&hook, 0, sizeof(PVR_MENUHOOK));
+        hook.iHookId = MENUHOOK_ID_MANUAL_REMINDER;
+        hook.iLocalizedStringId = 30111;
+        hook.category = PVR_MENUHOOK_CHANNEL;
+        PVR->AddMenuHook(&hook);
+
+        memset(&hook, 0, sizeof(PVR_MENUHOOK));
+        hook.iHookId = MENUHOOK_ID_CANCEL_CHANNEL_REMINDER;
+        hook.iLocalizedStringId = 30113;
+        hook.category = PVR_MENUHOOK_CHANNEL;
         PVR->AddMenuHook(&hook);
       }
       catch (FirmwareVersionException &e) {
@@ -276,6 +317,7 @@ extern "C" {
     UPDATE_INT("prefer_external_xmltv", bool, settings.m_preferExternalXmltv);
     UPDATE_INT("use_external_xmltv_icons", bool, settings.m_useExternalXmltvIcons);
     UPDATE_INT("set_channelid_using_order", ChannelOrder, settings.m_setChannelIdUsingOrder);
+    UPDATE_INT("reminder_mins_before_prog", unsigned int, settings.m_remindMinsBeforeProg)
     UPDATE_INT("timeshift_enabled", bool, settings.m_timeshiftEnabled);
     UPDATE_STR("timeshift_path", settings.m_timeshiftBufferPath);
 
@@ -1005,7 +1047,123 @@ extern "C" {
 
     return currentChannel != nullptr;
   }
-  
+
+  static bool SetEPGReminder(const PVR_MENUHOOK_DATA &item)
+  {
+    auto epgUid = item.data.iEpgUid;
+    ChannelPtr selectedChannel = nullptr;
+    const xmltv::ProgrammePtr programme = nullptr;
+
+    // find channel with the program in context
+    auto &channels = g_vbox->GetChannels();
+    auto it = std::find_if(channels.cbegin(), channels.cend(),
+      [&epgUid](const ChannelPtr &channel)
+    {
+      const Schedule schedule = g_vbox->GetSchedule(channel);
+      // Add a programme-based timer if the programme exists in the schedule
+      const xmltv::ProgrammePtr programme = (schedule.schedule) ? schedule.schedule->GetProgramme(epgUid) : nullptr;
+      return (programme != nullptr);
+    });
+    // if channel doesn't exist - return error
+    if (it == channels.cend())
+    {
+      XBMC->QueueNotification(QUEUE_ERROR, "Reminder could not find the requested channel");
+      return false;
+    }
+    else
+    {
+      // otherwise - get the program object and add a reminder with it as parameter
+      selectedChannel = *it;
+      const Schedule schedule = g_vbox->GetSchedule(selectedChannel);
+      const xmltv::ProgrammePtr programme = (schedule.schedule) ? schedule.schedule->GetProgramme(epgUid) : nullptr;
+      if (programme)
+      {
+        try {
+          g_vbox->AddReminder(selectedChannel, programme);
+        }
+        catch (VBoxException &e)
+        {
+          g_vbox->LogException(e);
+        }
+      }
+      else
+      {
+        XBMC->QueueNotification(QUEUE_ERROR, "Reminder could not find the requested channel");
+        return false;
+      }
+      XBMC->QueueNotification(QUEUE_INFO, "Reminder added");
+    }
+    return true;
+  }
+
+  const ChannelPtr FindChannelForEPGReminder(int epgUid)
+  {
+    const xmltv::ProgrammePtr programme = nullptr;
+    const std::vector<ChannelPtr> &channels = g_vbox->GetChannels();
+
+    // Find channel that contains this programme
+    const std::vector<ChannelPtr>::const_iterator it = std::find_if(channels.cbegin(), channels.cend(),
+      [&epgUid](const ChannelPtr &channel)
+    {
+      const Schedule schedule = g_vbox->GetSchedule(channel);
+      const xmltv::ProgrammePtr programme = (schedule.schedule) ? schedule.schedule->GetProgramme(epgUid) : nullptr;
+      return (programme);
+    });
+    // Find the channel's schedule
+    if (it == channels.cend())
+      XBMC->QueueNotification(QUEUE_WARNING, "Reminder could not find the requested channel");
+    return *it;
+  }
+
+  static time_t GetOffsetTime(time_t time)
+  {
+    std::string xmltvTime = g_vbox->CreateTimestamp(time);
+    std::string tzString = ::xmltv::Utilities::GetTimezoneOffset(xmltvTime);
+    return ::xmltv::Utilities::GetTimezoneAdjustment(tzString);
+  }
+
+  static bool SetManualReminder(const PVR_MENUHOOK_DATA &item)
+  {
+    time_t currTime = time(nullptr), reminderTime;
+    ChannelPtr selectedChannel = nullptr;
+    char buffer[256];
+
+    memset(buffer, 0, sizeof(buffer));
+    // get channel in context
+    selectedChannel = g_vbox->GetChannel(item.data.channel.iUniqueId);
+    if (!selectedChannel)
+      return false;
+
+    try {
+      // create the current time's formatted timestamp (for user input)
+      time_t tzOs = GetOffsetTime(currTime);
+      // add timezone offset
+      currTime += tzOs;
+      std::tm tm = *std::gmtime(&currTime);
+
+      // get program time & name (from user dialogs)
+      if (!GUI->Dialog_Numeric_ShowAndGetDate(tm, "Program starts at"))
+        return false;
+      if (!GUI->Dialog_Numeric_ShowAndGetTime(tm, "Program starts at"))
+        return false;
+      if (!GUI->Dialog_Keyboard_ShowAndGetInput(*buffer, sizeof(buffer), "Program title", true, false))
+        return false;
+
+      std::string progTitle(buffer); 
+      // remove timezone offset
+      reminderTime = compat::timegm(&tm) - tzOs;
+      // add reminder using manual time & title
+      g_vbox->AddReminder(selectedChannel, reminderTime, progTitle);
+    }
+    catch (VBoxException &e)
+    {
+      g_vbox->LogException(e);
+      return false;
+    }
+    XBMC->QueueNotification(QUEUE_INFO, "Reminder added");
+    return true;
+  }
+
   PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook, const PVR_MENUHOOK_DATA &item)
   {
     if (menuhook.category == PVR_MENUHOOK_SETTING)
@@ -1022,7 +1180,41 @@ extern "C" {
         g_vbox->SyncEPGNow();
         return PVR_ERROR_NO_ERROR;
       }
-	  return PVR_ERROR_INVALID_PARAMETERS;
+      return PVR_ERROR_INVALID_PARAMETERS;
+    }
+    if (menuhook.category == PVR_MENUHOOK_EPG)
+    {
+      if (menuhook.iHookId == MENUHOOK_ID_EPG_REMINDER)
+      {
+        if (SetEPGReminder(item))
+          return PVR_ERROR_NO_ERROR;
+      }
+      else if (menuhook.iHookId == MENUHOOK_ID_CANCEL_EPG_REMINDER)
+      {
+        if (g_vbox->KillProgramReminders(item.data.iEpgUid))
+          XBMC->QueueNotification(ADDON::QUEUE_INFO, "Reminder canceled");
+        else
+          XBMC->QueueNotification(ADDON::QUEUE_WARNING, "Program does not have a reminder to cancel");
+        return PVR_ERROR_NO_ERROR;
+      }
+      return PVR_ERROR_INVALID_PARAMETERS;
+    }
+    else if (menuhook.category == PVR_MENUHOOK_CHANNEL)
+    {
+      if (menuhook.iHookId == MENUHOOK_ID_MANUAL_REMINDER)
+      {
+        if (SetManualReminder(item))
+          return PVR_ERROR_NO_ERROR;
+      }
+      else if (menuhook.iHookId == MENUHOOK_ID_CANCEL_CHANNEL_REMINDER)
+      {
+        if (g_vbox->KillChannelReminders(g_vbox->GetChannel(item.data.channel.iUniqueId)))
+          XBMC->QueueNotification(ADDON::QUEUE_INFO, "Removed channel's existing reminders");
+        else
+          XBMC->QueueNotification(ADDON::QUEUE_WARNING, "Channel does not have reminders to cancel");
+        return PVR_ERROR_NO_ERROR;
+      }
+      return PVR_ERROR_INVALID_PARAMETERS;
     }
     return PVR_ERROR_NOT_IMPLEMENTED;
   }

--- a/src/client.h
+++ b/src/client.h
@@ -22,6 +22,7 @@
 
 #include "libXBMC_addon.h"
 #include "libXBMC_pvr.h"
+#include <libKODI_guilib.h>
 #include "vbox/VBox.h"
 
 #ifdef TARGET_WINDOWS
@@ -31,6 +32,7 @@
 // Helpers
 extern ADDON::CHelper_libXBMC_addon *XBMC;
 extern CHelper_libXBMC_pvr          *PVR;
+extern CHelper_libKODI_guilib       *GUI;
 
 // Globals
 extern ADDON_STATUS g_status;

--- a/src/vbox/Reminder.cpp
+++ b/src/vbox/Reminder.cpp
@@ -93,9 +93,9 @@ void Reminder::ComposeMessage(time_t currTime)
   }
 }
 
-std::string Reminder::GetReminderText(time_t currTime)
+std::string Reminder::GetReminderText()
 {
-  ComposeMessage(currTime);
+  ComposeMessage(time(nullptr));
   return m_msgText;
 }
 

--- a/src/vbox/Reminder.cpp
+++ b/src/vbox/Reminder.cpp
@@ -1,0 +1,110 @@
+/*
+*      Copyright (C) 2015 Sam Stenvall
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, write to
+*  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+*  MA 02110-1301  USA
+*  http://www.gnu.org/copyleft/gpl.html
+*
+*/
+#include "ContentIdentifier.h"
+#include "Reminder.h"
+#include <algorithm>
+#include "lib/tinyxml2/tinyxml2.h"
+#include "p8-platform/util/StringUtils.h"
+#include "Utilities.h"
+#include "Exceptions.h"
+#include "../client.h"
+
+using namespace vbox;
+using namespace tinyxml2;
+
+unsigned int Reminder::FindChannelNumber(const ChannelPtr &channel)
+{
+  if (g_vbox->GetSettings().m_setChannelIdUsingOrder == CH_ORDER_BY_LCN)
+  {
+     return channel->m_number;
+  }
+  else
+  {
+    auto &channels = g_vbox->GetChannels();
+    unsigned int i = 0;
+
+    for (const auto &item : channels)
+    {
+      ++i;
+      if (item == channel)
+        break;
+    }
+    return i;
+  }
+}
+
+Reminder::Reminder(const ChannelPtr &channel, const ::xmltv::ProgrammePtr &programme, unsigned int minsInAdvance) :
+  m_minsInAdvance(minsInAdvance), m_startTime(xmltv::Utilities::XmltvToUnixTime(programme->m_startTime)),
+  m_popTime(xmltv::Utilities::XmltvToUnixTime(programme->m_startTime) - (60 * m_minsInAdvance)), m_progName(programme->m_title), 
+  m_channelName(channel->m_name), m_channelXmltvName(channel->m_xmltvName)
+{
+  m_channelNum = FindChannelNumber(channel);
+}
+
+Reminder::Reminder(const ChannelPtr &channel, time_t startTime, std::string &progName, unsigned int minsInAdvance) :
+  m_minsInAdvance(minsInAdvance), m_startTime(startTime), 
+  m_popTime(startTime - (60 * m_minsInAdvance)), m_progName(progName),
+  m_channelName(channel->m_name), m_channelXmltvName(channel->m_xmltvName)
+{
+  m_channelNum = FindChannelNumber(channel);
+}
+
+void Reminder::ComposeMessage(time_t currTime)
+{
+  char buf[32], minBuf[32];
+
+  memset(minBuf, 0, sizeof(buf));
+  
+  sprintf(buf, "[%u] ", m_channelNum);
+
+  m_msgTitle = "Program reminder:";
+  m_msgText = "Program: " + std::string("    ") + m_progName + '\n';
+  m_msgText += "Channel: " + std::string("    ") +  std::string(buf) + m_channelName + '\n';
+  unsigned int minutes = (m_startTime - currTime) / 60;
+
+  m_msgText += "Starts ";
+
+  if (currTime < m_startTime && minutes > 0)
+  {
+    sprintf(minBuf, "%u", (m_startTime - currTime) / 60);
+    m_msgText += "in:     " + std::string(minBuf) + " minutes";
+  }
+  else
+  {
+    m_msgText += ":        Now";
+  }
+}
+
+std::string Reminder::GetReminderText(time_t currTime)
+{
+  ComposeMessage(currTime);
+  return m_msgText;
+}
+
+time_t Reminder::GetPopTime() const
+{
+  return m_popTime;
+}
+
+time_t Reminder::GetStartTime() const
+{
+  return m_startTime;
+}

--- a/src/vbox/Reminder.h
+++ b/src/vbox/Reminder.h
@@ -1,0 +1,77 @@
+#pragma once
+/*
+*      Copyright (C) 2015 Sam Stenvall
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, write to
+*  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+*  MA 02110-1301  USA
+*  http://www.gnu.org/copyleft/gpl.html
+*
+*/
+
+#include <string>
+#include "Channel.h"
+#include "../xmltv/Programme.h"
+#include "xbmc_pvr_types.h"
+
+namespace vbox {
+
+  class ReminderManager;
+
+  class Reminder
+  {
+  public:
+    Reminder(const ChannelPtr &channel, const ::xmltv::ProgrammePtr &programme, unsigned int minsInAdvance);
+    Reminder(const ChannelPtr &channel, time_t startTime, std::string &progName, unsigned int minsInAdvance);
+    ~Reminder() = default;
+    std::string GetReminderText(time_t currTime);
+    time_t GetPopTime() const;
+    time_t GetStartTime() const;
+
+  private:
+    friend ReminderManager;
+
+    static unsigned int FindChannelNumber(const ChannelPtr &channel);
+    void ComposeMessage(time_t currTime);
+
+    unsigned int m_minsInAdvance;
+    time_t m_startTime;
+    time_t m_popTime;
+    std::string m_channelXmltvName;
+    unsigned int m_channelNum;
+    std::string m_channelName;
+    std::string m_progName;
+    std::string m_msgTitle;
+    std::string m_msgText;
+  };
+
+  typedef std::shared_ptr<Reminder> ReminderPtr;
+
+  class ReminderComparison
+  {
+    bool reverse;
+  public:
+    ReminderComparison(const bool& revparam = true)
+    {
+      reverse = revparam;
+    }
+    bool operator() (ReminderPtr &lhs, ReminderPtr &rhs) const
+    {
+      if (reverse) 
+        return (lhs->GetPopTime() > rhs->GetPopTime());
+      else 
+        return (rhs->GetPopTime() > lhs->GetPopTime());
+    }
+  };
+}

--- a/src/vbox/Reminder.h
+++ b/src/vbox/Reminder.h
@@ -29,20 +29,70 @@ namespace vbox {
 
   class ReminderManager;
 
+  /**
+  * Represents a single-program reminder. 
+  * Contains a message reminding the user of the program
+  */
   class Reminder
   {
   public:
+    
+    /**
+    * Creates a reminder from a channel and a specific program
+    * @param channel the channel containing the program to remind
+    * @param programme the program to remind
+    * @param minsInAdvance minutes before the program's start time to pop the reminder
+    */
     Reminder(const ChannelPtr &channel, const ::xmltv::ProgrammePtr &programme, unsigned int minsInAdvance);
+    
+    /**
+    * Creates a reminder according to a manually given program name and its' start time
+    * @param channel the channel containing the program to remind
+    * @param startTime the program's original start time
+    * @param minsInAdvance minutes before the program's start time to pop the reminder
+    */
     Reminder(const ChannelPtr &channel, time_t startTime, std::string &progName, unsigned int minsInAdvance);
-    ~Reminder() = default;
-    std::string GetReminderText(time_t currTime);
+    
+    /**
+    * For comparing reminders' pop times
+    */
+    bool operator< (const Reminder &other) const
+    {
+      return !(m_popTime < other.m_popTime);
+    }
+
+    /**
+    * Composes & returns a message for a certain moment in time, showing details 
+    * of the program and the time left for it to start
+    * @param currTime the current time of showing the reminder pop-up
+    * @return the reminder's pop-up message
+    */
+    std::string GetReminderText();
+
+    /**
+    * @return the reminder's pop time
+    */
     time_t GetPopTime() const;
+
+    /**
+    * @return the program's original start time
+    */
     time_t GetStartTime() const;
 
   private:
     friend ReminderManager;
 
+    /**
+    * Finds a channel's display number in the addon (LCN / index - varies by setting)
+    * @param channel the requested channel
+    * @return the channel's number
+    */
     static unsigned int FindChannelNumber(const ChannelPtr &channel);
+
+    /**
+    * Composes the reminder's message
+    * @param currTime the time of showing the popup (pop time)
+    */
     void ComposeMessage(time_t currTime);
 
     unsigned int m_minsInAdvance;
@@ -57,21 +107,4 @@ namespace vbox {
   };
 
   typedef std::shared_ptr<Reminder> ReminderPtr;
-
-  class ReminderComparison
-  {
-    bool reverse;
-  public:
-    ReminderComparison(const bool& revparam = true)
-    {
-      reverse = revparam;
-    }
-    bool operator() (ReminderPtr &lhs, ReminderPtr &rhs) const
-    {
-      if (reverse) 
-        return (lhs->GetPopTime() > rhs->GetPopTime());
-      else 
-        return (rhs->GetPopTime() > lhs->GetPopTime());
-    }
-  };
 }

--- a/src/vbox/ReminderManager.cpp
+++ b/src/vbox/ReminderManager.cpp
@@ -1,0 +1,330 @@
+/*
+*      Copyright (C) 2015 Sam Stenvall
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, write to
+*  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+*  MA 02110-1301  USA
+*  http://www.gnu.org/copyleft/gpl.html
+*
+*/
+#include "ContentIdentifier.h"
+#include "ReminderManager.h"
+#include <algorithm>
+#include "lib/tinyxml2/tinyxml2.h"
+#include "p8-platform/util/StringUtils.h"
+#include "Utilities.h"
+#include "Exceptions.h"
+#include "../client.h"
+
+using namespace vbox;
+using namespace tinyxml2;
+
+const std::string ReminderManager::REMINDERS_XML = "special://userdata/addon_data/pvr.vbox/reminders.xml";
+
+void ReminderManager::Initialize()
+{
+  if (!XBMC->FileExists(REMINDERS_XML.c_str(), false))
+  {
+    g_vbox->Log(ADDON::LOG_INFO, "No reminders XML found");
+    Save();
+  }
+  else
+  {
+    g_vbox->Log(ADDON::LOG_INFO, "Reminders XML found");
+    Load();
+  }
+}
+
+bool ReminderManager::AddReminder(const ChannelPtr &channel, const ::xmltv::ProgrammePtr &programme, unsigned int minsBeforePop)
+{
+  // Construct the object
+  ReminderPtr reminder(new Reminder(channel, programme, minsBeforePop));
+  // save in queue
+  g_vbox->Log(ADDON::LOG_DEBUG, "Added reminder (1) for channel %s, prog %s", programme->m_channelName.c_str(), programme->m_title.c_str());
+  m_reminders.push(reminder);
+  Save();
+  return true;
+}
+
+bool ReminderManager::AddReminder(const ChannelPtr &channel, time_t startTime, std::string &progName, unsigned int minsBeforePop)
+{
+  g_vbox->Log(ADDON::LOG_DEBUG, "Added reminder for %s", g_vbox->CreateTimestamp(startTime).c_str());
+  // Construct the object
+  ReminderPtr reminder(new Reminder(channel, startTime, progName, minsBeforePop));
+  // save in queue
+  g_vbox->Log(ADDON::LOG_DEBUG, "Added reminder (2) for channel %s, prog %s", channel->m_name.c_str(), progName.c_str());
+  m_reminders.push(reminder);
+  Save();
+  return true;
+}
+
+ReminderPtr ReminderManager::GetReminderToPop(time_t currTime)
+{
+  if (m_reminders.empty())
+  {
+    return nullptr;
+  }
+  ReminderPtr reminder = m_reminders.top();
+  if (reminder)
+  {
+    time_t popTime = reminder->GetPopTime();
+    time_t startTime = reminder->GetStartTime();
+
+    // if past pop time - handle reminder
+    if (currTime > popTime)
+    {
+      // if we're somewhere between the pop time and the first
+      // 5 first minutes of the program (addon might have not been active) - pop reminder
+      if (currTime < startTime + 5 * 60)
+      {
+        g_vbox->Log(ADDON::LOG_DEBUG, "Reminder popped");
+        return reminder;
+      }
+      // reminder is too old - kill it
+      else
+      {
+        KillNextReminder();
+      }
+    }
+  }
+  return nullptr;
+}
+
+void ReminderManager::KillNextReminder()
+{
+  g_vbox->Log(ADDON::LOG_DEBUG, "Popping reminder!");
+  m_reminders.pop();
+  Save();
+}
+
+bool ReminderManager::KillChannelReminders(const ChannelPtr &rChannel)
+{
+  bool fSuccess = false;
+  ReminderQueue queue;
+
+  g_vbox->Log(ADDON::LOG_INFO, "KillChannelReminders(): in");
+  while (!m_reminders.empty())
+  {
+    ReminderPtr reminder = m_reminders.top();
+    m_reminders.pop();
+    std::string channelId = reminder->m_channelXmltvName;
+    // find matching channel
+    auto &channels = g_vbox->GetChannels();
+    auto it = std::find_if(channels.cbegin(), channels.cend(),
+      [&channelId](const ChannelPtr &channel)
+    {
+      return channelId == channel->m_xmltvName;
+    });
+
+    // if channel does not match - keep reminder
+    if (it != channels.end())
+    {
+      const ChannelPtr &selectedChannel = *it;
+      if (rChannel == selectedChannel)
+      {
+        g_vbox->Log(ADDON::LOG_INFO, "Removing reminder, matches channel %s", selectedChannel->m_xmltvName.c_str());
+        fSuccess = true;
+        continue;
+      }
+    }
+    queue.push(reminder);
+  }
+  m_reminders = queue;
+  g_vbox->Log(ADDON::LOG_INFO, "KillChannelReminders(): out");
+  if (fSuccess)
+    Save();
+  return fSuccess;
+}
+
+
+bool ReminderManager::KillProgramReminders(unsigned int epgUid)
+{
+  bool fSuccess = false;
+  ReminderQueue queue;
+
+  g_vbox->Log(ADDON::LOG_INFO, "KillProgramReminders(): in");
+  while (!m_reminders.empty())
+  {
+    ReminderPtr reminder = m_reminders.top();
+    m_reminders.pop();
+    std::string channelId = reminder->m_channelXmltvName;
+
+    auto &channels = g_vbox->GetChannels();
+    auto it = std::find_if(channels.cbegin(), channels.cend(),
+      [&channelId](const ChannelPtr &channel)
+    {
+      return channelId == channel->m_xmltvName;
+    });
+
+    // if channel does not match - keep reminder & continue
+    if (it != channels.end())
+    {
+      const ChannelPtr &selectedChannel = *it;
+      g_vbox->Log(ADDON::LOG_INFO, "KillProgramReminders(): found channel %s", selectedChannel->m_xmltvName.c_str());
+      const Schedule schedule = g_vbox->GetSchedule(selectedChannel);
+      const xmltv::ProgrammePtr programme = (schedule.schedule) ? schedule.schedule->GetProgramme(epgUid) : nullptr;
+      // skip reminder if the EPG event is found
+      if (programme && programme->m_title == reminder->m_progName && xmltv::Utilities::XmltvToUnixTime(programme->m_startTime) == reminder->m_startTime)
+      {
+        g_vbox->Log(ADDON::LOG_INFO, "KillProgramReminders(): found program. queue size %d, m_reminders size %d", queue.size(), m_reminders.size());
+        fSuccess = true;
+        continue;
+      }
+    }
+    queue.push(reminder);
+  }
+  m_reminders = queue;
+  g_vbox->Log(ADDON::LOG_INFO, "KillProgramReminders(): out");
+  if (fSuccess)
+    Save();
+  return fSuccess;
+}
+
+
+void ReminderManager::Load()
+{
+  g_vbox->Log(ADDON::LOG_INFO, "Found reminders XML file, attempting to load it");
+  void *fileHandle = XBMC->OpenFile(REMINDERS_XML.c_str(), 0x08 /* READ_NO_CACHE */);
+
+  if (!fileHandle)
+  {
+    g_vbox->Log(ADDON::LOG_ERROR, "Could not open reminders XML");
+    return;
+  }
+
+  while (!m_reminders.empty())
+    m_reminders.pop();
+
+  g_vbox->Log(ADDON::LOG_INFO, "Reading XML");
+  // Read the XML
+  tinyxml2::XMLDocument document;
+  std::unique_ptr<std::string> contents = utilities::ReadFileContents(fileHandle);
+
+  // Try to parse the document
+  if (document.Parse(contents->c_str(), contents->size()) != XML_NO_ERROR)
+    throw vbox::InvalidXMLException("XML parsing failed: " + std::string(document.ErrorName()));
+
+  unsigned int minsBeforePop = g_vbox->GetSettings().m_remindMinsBeforeProg;
+  // Create mappings
+  for (const XMLElement *element = document.RootElement()->FirstChildElement("reminder");
+    element != nullptr; element = element->NextSiblingElement("reminder"))
+  {
+    g_vbox->Log(ADDON::LOG_INFO, "Found reminder");
+    // get channel, program name and start time
+    const char *pXmltvId = element->Attribute("channel");
+    const char *pStartTime = element->Attribute("start-time");
+    const char *pProgName = element->GetText();
+    g_vbox->Log(ADDON::LOG_INFO, "Reminder  1 is for ch %s, startTime %s", pXmltvId, pStartTime);
+    std::string progTitle(pProgName? pProgName : "");
+    g_vbox->Log(ADDON::LOG_INFO, "Reminder 2 is for ch %s, startTime %s, progTitle=%s", pXmltvId, pStartTime, progTitle.c_str());
+    if (!pXmltvId || !pStartTime)
+      continue;
+
+    g_vbox->Log(ADDON::LOG_INFO, "Reminder 3 is for ch %s, startTime %s", pXmltvId, pStartTime);
+    std::string encodedChId(pXmltvId);
+    std::string xmltvStartTime(pStartTime);
+    time_t startTime(xmltv::Utilities::XmltvToUnixTime(xmltvStartTime));
+    g_vbox->Log(ADDON::LOG_INFO, "Reminder is for encodedChId %s, looking for it", encodedChId.c_str());
+    // Find the channel the reminder is for
+    auto &channels = g_vbox->GetChannels();
+    auto it = std::find_if(channels.cbegin(), channels.cend(),
+      [&encodedChId](const ChannelPtr &channel)
+    {
+      g_vbox->Log(ADDON::LOG_INFO, "Channel is %s when looking for %s", channel->m_xmltvName.c_str(), encodedChId.c_str());
+      return encodedChId == channel->m_xmltvName;
+    });
+
+    if (it == channels.end())
+    {
+      g_vbox->Log(ADDON::LOG_INFO, "Channel of reminder not found, continuing");
+      continue;
+    }
+    const ChannelPtr channel = *it;
+
+    g_vbox->Log(ADDON::LOG_INFO, "Channel found, it's %s, adding reminder to queue", channel->m_xmltvName.c_str());
+    if (!AddReminder(channel, startTime, progTitle, minsBeforePop))
+      g_vbox->Log(ADDON::LOG_ERROR, "Could not load reminder");
+    else
+      g_vbox->Log(ADDON::LOG_INFO, "Channel found, it's %s, added reminder to queue", channel->m_xmltvName.c_str());
+  }
+  XBMC->CloseFile(fileHandle);
+}
+
+void ReminderManager::Save()
+{
+  ReminderQueue queue;
+
+  // Create the document
+  tinyxml2::XMLDocument document;
+  XMLDeclaration *declaration = document.NewDeclaration();
+  document.InsertEndChild(declaration);
+
+  // Create the root node (<reminders>)
+  XMLElement *rootElement = document.NewElement("reminders");
+  document.InsertEndChild(rootElement);
+  g_vbox->Log(ADDON::LOG_INFO, "Save(1): %u reminders", m_reminders.size());
+
+  // Create one <reminder> for every reminder
+  while (!m_reminders.empty())
+  {
+    ReminderPtr reminder = m_reminders.top();
+    g_vbox->Log(ADDON::LOG_INFO, "Save(2): got reminder", m_reminders.size());
+    XMLElement *reminderElement = document.NewElement("reminder");
+    reminderElement->SetText(reminder->m_progName.c_str());
+    reminderElement->SetAttribute("channel", reminder->m_channelXmltvName.c_str());
+    reminderElement->SetAttribute("start-time", g_vbox->CreateTimestamp(reminder->m_startTime).c_str());
+    rootElement->InsertFirstChild(reminderElement);
+    m_reminders.pop();
+    g_vbox->Log(ADDON::LOG_INFO, "Save(3): popped. Now pushing to queue", m_reminders.size());
+    queue.push(reminder);
+  }
+  g_vbox->Log(ADDON::LOG_INFO, "Save(4): queue size %d, m_reminders size %d", queue.size(), m_reminders.size());
+  m_reminders = queue;
+  g_vbox->Log(ADDON::LOG_INFO, "Save(5): queue size %d, m_reminders size %d", queue.size(), m_reminders.size());
+  
+  XBMC->DeleteFile(REMINDERS_XML.c_str());
+  // Save the file
+  void *fileHandle = XBMC->OpenFileForWrite(REMINDERS_XML.c_str(), false);
+
+  if (fileHandle)
+  {
+    XMLPrinter printer;
+    document.Accept(&printer);
+
+    //XBMC->TruncateFile()
+    std::string xml = printer.CStr();
+    XBMC->WriteFile(fileHandle, xml.c_str(), xml.length());
+
+    XBMC->CloseFile(fileHandle);
+  }
+}
+
+/*std::vector<ReminderPtr> ReminderManager::GetReminderVector()
+{
+  std::vector<ReminderPtr> vec;
+  ReminderQueue queue;
+
+  g_vbox->Log(ADDON::LOG_INFO, "GetReminderVector(): in");
+  while (!m_reminders.empty())
+  {
+    g_vbox->Log(ADDON::LOG_INFO, "GetReminderVector(): got 1");
+    ReminderPtr reminder = m_reminders.top();
+    m_reminders.pop();
+    vec.push_back(reminder);
+    queue.push(reminder);
+  }
+  m_reminders = queue;
+  g_vbox->Log(ADDON::LOG_INFO, "GetReminderVector(): out");
+  return vec;
+}*/

--- a/src/vbox/ReminderManager.h
+++ b/src/vbox/ReminderManager.h
@@ -1,0 +1,65 @@
+#pragma once
+/*
+*      Copyright (C) 2015 Sam Stenvall
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, write to
+*  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+*  MA 02110-1301  USA
+*  http://www.gnu.org/copyleft/gpl.html
+*
+*/
+
+#include <string>
+#include <vector>
+#include <queue>
+#include <functional>
+#include "Reminder.h"
+#include "../xmltv/Programme.h"
+#include "xbmc_pvr_types.h"
+
+namespace vbox {
+
+  typedef std::priority_queue<ReminderPtr, std::vector<ReminderPtr>, ReminderComparison> ReminderQueue;
+  typedef std::unique_ptr<ReminderQueue> ReminderQueuePtr;
+
+  class ReminderManager
+  {
+  public:
+    ReminderManager() = default;
+    ~ReminderManager() = default;
+    void Initialize();
+    bool AddReminder(const ChannelPtr &channel, const ::xmltv::ProgrammePtr &programme, unsigned int minsBeforePop);
+    bool AddReminder(const ChannelPtr &channel, time_t startTime, std::string &progName, unsigned int minsBeforePop);
+    ReminderPtr GetReminderToPop(time_t currTime);
+    void KillNextReminder();
+    bool KillChannelReminders(const ChannelPtr &channel);
+    bool KillProgramReminders(unsigned int epgUid);
+    void Load();
+    void Save();
+
+  private:
+
+    /**
+    * The path to the reminders XML file
+    */
+    const static std::string REMINDERS_XML;
+
+    /**
+    * The queue of reminders (prioritized by earliest)
+    */
+    ReminderQueue m_reminders;
+  };
+
+  typedef std::unique_ptr<ReminderManager> ReminderManagerPtr;
+}

--- a/src/vbox/ReminderManager.h
+++ b/src/vbox/ReminderManager.h
@@ -30,22 +30,72 @@
 
 namespace vbox {
 
-  typedef std::priority_queue<ReminderPtr, std::vector<ReminderPtr>, ReminderComparison> ReminderQueue;
+  typedef std::priority_queue<ReminderPtr, std::vector<ReminderPtr> > ReminderQueue;
   typedef std::unique_ptr<ReminderQueue> ReminderQueuePtr;
 
+  /**
+  * Represents a reminder manager, which creates, stores and manages reminders
+  * according to the time they're supposed to pop. It stores the reminders to disk
+  */
   class ReminderManager
   {
   public:
     ReminderManager() = default;
     ~ReminderManager() = default;
+
+    /**
+    * Initializes the manager by loading previously set reminders from disk
+    * if no XML exists, saves the current reminders to disk
+    */
     void Initialize();
+
+    /**
+    * Creates and stores a reminder with a given channel and program
+    * @param channel the channel containing the program to remind
+    * @param programme the program to remind
+    * @param minsInAdvance minutes before the program's start time to pop the reminder
+    * @return the success of adding the newly created reminder
+    */
     bool AddReminder(const ChannelPtr &channel, const ::xmltv::ProgrammePtr &programme, unsigned int minsBeforePop);
+    
+    /**
+    * Creates and stores a reminder with a given channel, and a manually given program name and its' start time
+    * @param channel the channel containing the program to remind
+    * @param programme the program to remind
+    * @param minsInAdvance minutes before the program's start time to pop the reminder
+    * @return the success of adding the newly created reminder
+    */
     bool AddReminder(const ChannelPtr &channel, time_t startTime, std::string &progName, unsigned int minsBeforePop);
+
+    /**
+    * @param currTime the current time
+    * @return the reminder at the top of the queue
+    */
     ReminderPtr GetReminderToPop(time_t currTime);
-    void KillNextReminder();
-    bool KillChannelReminders(const ChannelPtr &channel);
-    bool KillProgramReminders(unsigned int epgUid);
+
+    /**
+    * Removes the reminder at the top of the queue
+    */
+    void DeleteNextReminder();
+
+    /**
+    * Removes all reminder set for a channel (if exist)
+    */
+    bool DeleteChannelReminders(const ChannelPtr &channel);
+
+    /**
+    * Removes a program's reminder (if exists)
+    */
+    bool DeleteProgramReminders(unsigned int epgUid);
+
+    /**
+    * Loads reminders from disk
+    */
     void Load();
+
+    /**
+    * Saves reminders to disk
+    */
     void Save();
 
   private:

--- a/src/vbox/Settings.h
+++ b/src/vbox/Settings.h
@@ -92,6 +92,7 @@ namespace vbox {
     bool m_preferExternalXmltv;
     bool m_useExternalXmltvIcons;
     ChannelOrder m_setChannelIdUsingOrder;
+    unsigned int m_remindMinsBeforeProg;
     bool m_timeshiftEnabled;
     std::string m_timeshiftBufferPath;
   };

--- a/src/vbox/VBox.cpp
+++ b/src/vbox/VBox.cpp
@@ -43,7 +43,7 @@ using namespace vbox;
 const char * VBox::MINIMUM_SOFTWARE_VERSION = "2.48";
 
 VBox::VBox(const Settings &settings)
-  : m_settings(settings), m_currentChannel(nullptr), m_categoryGenreMapper(nullptr), m_shouldSyncEpg(false)
+  : m_settings(settings), m_currentChannel(nullptr), m_categoryGenreMapper(nullptr), m_shouldSyncEpg(false), m_reminderManager(nullptr)
 {
 }
 
@@ -221,6 +221,42 @@ void VBox::UpdateEpgScan(bool fRetrieveGuide)
   }
 }
 
+void VBox::RetrieveReminders()
+{
+  // Abort if we're already initialized
+  if (!m_reminderManager)
+  {
+    Log(LOG_INFO, "Loading reminders manager");
+
+    m_reminderManager = ReminderManagerPtr(new ReminderManager());
+
+    try {
+      m_reminderManager->Initialize();
+    }
+    catch (VBoxException &e)
+    {
+      LogException(e);
+      Log(LOG_INFO, "Failed to load the reminders XML");
+    }
+  }
+  m_reminderManager->Load();
+}
+
+
+
+void VBox::CheckForActiveReminder()
+{
+  time_t currTime = time(nullptr);
+  // check if reminder needed
+  ReminderPtr reminder = m_reminderManager->GetReminderToPop(currTime);
+
+  if (reminder)
+  {
+    GUI->Dialog_OK_ShowAndGetInput("Program reminder", std::string(reminder->GetReminderText(currTime)).c_str());
+    m_reminderManager->KillNextReminder();
+  }
+}
+
 void VBox::BackgroundUpdater()
 {
   // Keep count of how many times the loop has run so we can perform some 
@@ -230,6 +266,7 @@ void VBox::BackgroundUpdater()
   // Retrieve everything in order once before starting the loop, without 
   // triggering the event handlers
   RetrieveChannels(false);
+  RetrieveReminders();
 
   InitializeGenreMapper();
   RetrieveRecordings(false);
@@ -247,6 +284,9 @@ void VBox::BackgroundUpdater()
 
   while (m_active)
   {
+    // check for reminders each iteration
+    CheckForActiveReminder();
+
     // Update recordings every 12 iterations = 1 minute
     if (lapCounter % 12 == 0)
       RetrieveRecordings();
@@ -380,6 +420,26 @@ const ChannelPtr VBox::GetCurrentChannel() const
 void VBox::SetCurrentChannel(const ChannelPtr &channel)
 {
   m_currentChannel = channel;
+}
+
+bool VBox::AddReminder(const ChannelPtr &channel, const ::xmltv::ProgrammePtr &programme)
+{
+  return m_reminderManager->AddReminder(channel, programme, m_settings.m_remindMinsBeforeProg);
+}
+
+bool VBox::AddReminder(const ChannelPtr &channel, time_t startTime, std::string &progName)
+{
+  return m_reminderManager->AddReminder(channel, startTime, progName, m_settings.m_remindMinsBeforeProg);
+}
+
+bool VBox::KillChannelReminders(const ChannelPtr &channel)
+{
+  return m_reminderManager->KillChannelReminders(channel);
+}
+
+bool VBox::KillProgramReminders(unsigned int epgUid)
+{
+  return m_reminderManager->KillProgramReminders(epgUid);
 }
 
 void VBox::StartEPGScan()

--- a/src/vbox/VBox.h
+++ b/src/vbox/VBox.h
@@ -184,8 +184,8 @@ namespace vbox {
     // Reminder methods
     bool AddReminder(const ChannelPtr &channel, const ::xmltv::ProgrammePtr &programme);
     bool AddReminder(const ChannelPtr &channel, time_t startTime, std::string &progName);
-    bool KillChannelReminders(const ChannelPtr &channel);
-    bool KillProgramReminders(unsigned int epgUid);
+    bool DeleteChannelReminders(const ChannelPtr &channel);
+    bool DeleteProgramReminders(unsigned int epgUid);
 
     // Helpers
     static void Log(const ADDON::addon_log level, const char *format, ...);
@@ -205,7 +205,8 @@ namespace vbox {
     void RetrieveRecordings(bool triggerEvent = true);
     void RetrieveGuide(bool triggerEvent = true);
     void RetrieveExternalGuide(bool triggerEvent = true);
-    void CheckForActiveReminder();
+    ReminderPtr GetActiveReminder();
+    void DisplayReminder(const ReminderPtr &reminder);
     void RetrieveReminders();
     void InitializeChannelMapper();
     void InitializeGenreMapper();
@@ -243,10 +244,10 @@ namespace vbox {
      */
     std::vector<RecordingPtr> m_recordings;
 
-	/**
-	* The list of recordings, including timeres
-	*/
-	std::vector<SeriesRecordingPtr> m_series;
+    /**
+    * The list of recordings, including timeres
+    */
+    std::vector<SeriesRecordingPtr> m_series;
 
     /**
      * The guide data. The XMLTV channel name is the key, the value is the 

--- a/src/vbox/VBox.h
+++ b/src/vbox/VBox.h
@@ -33,6 +33,8 @@
 #include "CategoryGenreMapper.h"
 #include "Recording.h"
 #include "SeriesRecording.h"
+#include "Reminder.h"
+#include "ReminderManager.h"
 #include "Exceptions.h"
 #include "Settings.h"
 #include "SoftwareVersion.h"
@@ -179,6 +181,12 @@ namespace vbox {
     void StartEPGScan();
     void SyncEPGNow();
 
+    // Reminder methods
+    bool AddReminder(const ChannelPtr &channel, const ::xmltv::ProgrammePtr &programme);
+    bool AddReminder(const ChannelPtr &channel, time_t startTime, std::string &progName);
+    bool KillChannelReminders(const ChannelPtr &channel);
+    bool KillProgramReminders(unsigned int epgUid);
+
     // Helpers
     static void Log(const ADDON::addon_log level, const char *format, ...);
     static void LogException(VBoxException &e);
@@ -197,6 +205,8 @@ namespace vbox {
     void RetrieveRecordings(bool triggerEvent = true);
     void RetrieveGuide(bool triggerEvent = true);
     void RetrieveExternalGuide(bool triggerEvent = true);
+    void CheckForActiveReminder();
+    void RetrieveReminders();
     void InitializeChannelMapper();
     void InitializeGenreMapper();
     void SwapChannelIcons(std::vector<ChannelPtr> &channels);
@@ -258,6 +268,11 @@ namespace vbox {
      * The category<->genre mapper
      */
     CategoryMapperPtr m_categoryGenreMapper;
+
+    /**
+    * The reminder manager
+    */
+    ReminderManagerPtr  m_reminderManager;
 
     /**
      * Handler for the startup state


### PR DESCRIPTION
Before I start: those are not reminders that you can switch a channel with (those exist as seperate addons), but those are simple "OK" popups with the program details that pop up before your program - for whatever number of minutes that you set.
The number of minutes of that interval are set through the settings->EPG tab.

Reminders can be set/canceled from 2 places:
1. Through EPG context menu - can be set / canceled per program.
2. Through the channels context menu - can be set (manually - date, time and program name), or canceled for the entire channel (cancels all reminders for that channel).
Notifications show after those actions.