### PR TITLE
Bypass DB version check when manually syncing EPG

### DIFF
--- a/src/vbox/VBox.cpp
+++ b/src/vbox/VBox.cpp
@@ -938,7 +938,7 @@ void VBox::RetrieveGuide(bool triggerEvent/* = true*/)
     std::string progsDBVerName("ProgramsDataBaseVersion");
 
     // if same as last fetched guide, no need for fetching again
-    if (IsDBContentUpdated(progsDBVerName, m_programsDBVersion, newDBversion))
+    if (!m_shouldSyncEpg && IsDBContentUpdated(progsDBVerName, m_programsDBVersion, newDBversion))
       return;
 
     // Retrieving the whole XMLTV file is too slow so we fetch sections in 


### PR DESCRIPTION
When syncing EPG manually (through TV settings->client specific settings) - need to bypass the version check in case user wants the same EPG fetched again from the firmware.