### PR TITLE
Fixed crash due to channels with empty name

### DIFF
--- a/src/vbox/response/Content.cpp
+++ b/src/vbox/response/Content.cpp
@@ -96,8 +96,8 @@ ChannelPtr XMLTVResponseContent::CreateChannel(const tinyxml2::XMLElement *xml) 
 {
   // Extract data from the various <display-name> elements
   const XMLElement *displayElement = xml->FirstChildElement("display-name");
-
-  std::string name = displayElement->GetText();
+  const char *pChannelName = displayElement->GetText();
+  std::string name = pChannelName ? pChannelName : "";
   displayElement = displayElement->NextSiblingElement("display-name");
   std::string type = displayElement->GetText();
   displayElement = displayElement->NextSiblingElement("display-name");

--- a/src/xmltv/Guide.cpp
+++ b/src/xmltv/Guide.cpp
@@ -37,7 +37,8 @@ Guide::Guide(const XMLElement *m_content)
   {
     // Create the channel
     std::string channelId = Utilities::UrlDecode(element->Attribute("id"));
-    std::string displayName = element->FirstChildElement("display-name")->GetText();
+    const char *pChannelName = element->FirstChildElement("display-name")->GetText();
+    std::string displayName = pChannelName ? pChannelName : "";
     ChannelPtr channel = ChannelPtr(new Channel(channelId, displayName));
 
     // Add channel icon if it exists


### PR DESCRIPTION
Channels with whitespaces (space for example) as channel name had the whitespaces cleared out, returned NULL, given to std::string constructor and crashed the addon.
Now, I know there shouldn't be such a channel name, but no-name is a valid channel name in the VBox firmware. Its channel ID is still unique.