### PR TITLE
Fixed previous coverity issues

### DIFF
--- a/src/vbox/Reminder.cpp
+++ b/src/vbox/Reminder.cpp
@@ -84,7 +84,7 @@ void Reminder::ComposeMessage(time_t currTime)
 
   if (currTime < m_startTime && minutes > 0)
   {
-    sprintf(minBuf, "%u", (m_startTime - currTime) / 60);
+    sprintf(minBuf, "%li", (m_startTime - currTime) / 60);
     m_msgText += "in:     " + std::string(minBuf) + " minutes";
   }
   else

--- a/src/vbox/response/Content.cpp
+++ b/src/vbox/response/Content.cpp
@@ -228,7 +228,7 @@ static void AddWeekdayBits(unsigned int &rWeekdays, const char *pWeekdaysText)
   char *pDay;
   char buf[32];
 
-  strcpy(buf, pWeekdaysText);
+  strncpy(buf, pWeekdaysText, sizeof(buf));
   pDay = strtok(buf, ",");
 
   while (pDay)


### PR DESCRIPTION
1. Printf format for time_t.
2. A case (that shouldn't have happened anyway) in which I would try to de-reference the end of the vector.
3. Possible (also shouldn't have happened anyway) buffer overflow when copying a string.