### PR TITLE
[cmake] remove usage of kodi-platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,11 +7,9 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 enable_language(CXX)
 
 find_package(Kodi REQUIRED)
-find_package(kodiplatform REQUIRED)
 find_package(p8-platform REQUIRED)
 
-include_directories(${kodiplatform_INCLUDE_DIRS}
-                    ${p8-platform_INCLUDE_DIRS}
+include_directories(${p8-platform_INCLUDE_DIRS}
                     ${KODI_INCLUDE_DIR}
                     ${PROJECT_SOURCE_DIR})
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: kodi-pvr-vbox
 Priority: extra
 Maintainer: Sam Stenvall <sam.stenvall@kodi.tv>
 Build-Depends: debhelper (>= 9.0.0), cmake,
-               libkodiplatform-dev (>= 16.0.0), kodi-addon-dev
+               libp8-platform-dev, kodi-addon-dev
 Standards-Version: 3.9.4
 Section: libs
 Homepage: https://github.com/Jalle19/pvr.vbox


### PR DESCRIPTION
The pvr.vbox binary addon does not use kodi-platform.
Remove existing references from CMakeLists.txt and debian/control.