### PR TITLE
[pvr.vbox] bump to 5.1.0

### DIFF
--- a/pvr.vbox/addon.xml.in
+++ b/pvr.vbox/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vbox"
-  version="5.0.0"
+  version="5.1.0"
   name="VBox TV Gateway PVR Client"
   provider-name="Sam Stenvall">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.vbox/changelog.txt
+++ b/pvr.vbox/changelog.txt
@@ -1,3 +1,6 @@
+5.1.0
+    - Update to GUI addon API v5.14.0
+
 5.0.0
     - Update to PVR addon API v6.0.0
 


### PR DESCRIPTION
Due to https://github.com/xbmc/xbmc/pull/16444 and GUI API breakage, a version bump is required