### PR TITLE
Boot crash fix matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ These instructions may be outdated. I'm assuming here that you'll check out all 
 
 ## Settings
 
-There are two tabs in the settings dialog with identical settings, which means you can configure your addon to contact the VBox TV Gateway using both its internal and external address/port. This is useful for e.g. a laptop which is not permanently inside your internal network. When the addon starts it first attempts to make a connection using the internal settings. If that fails, it will try the external settings instead. The addon restarts itself if the connection is lost so it will automatically switch back without having to restart Kodi.
+It's possible to configure the addon to connect to the VBox TV Gateway using both the local netowrk and via the internet address/port. This is useful for e.g. a laptop which is not permanently inside your internal network. When the addon starts it first attempts to make a connection using the local network settings. If that fails, it will try the internet settings instead. The addon restarts itself if the connection is lost so it will automatically switch back without having to restart Kodi.
 
 ### Connection - Internal
 Connection settings to use when connecting from your local network. For a local network connection the port values should not need to be modified.
@@ -79,9 +79,9 @@ Connection settings to use when connecting from the internet. The ports should o
 * **Connection timeout (seconds)**: The value used (in seconds) to denote when a connection attempt has failed when accessed from the internet. Default value is `10`.
 
 ### EPG
-Settings related to the EPG.
+Settings related to Channels & EPG.
 
-* **Channel numbers set by**: Channel numbers be set via either of the following two options:
+* **Channel numbers set by**: Channel numbers can be set via either of the following two options:
     - `LCN (Logical Channel Number) from backend` - The channel numbers as set on the backend.
     - `Channel index in backend` - Starting from 1 number the channels as per the order they appear on the backend.
 * **Reminder time (minutes before programme start)**: The amount of time in minutes prior to a programme start that a reminder should pop up.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Settings related to the EPG.
     - `LCN (Logical Channel Number) from backend` - The channel numbers as set on the backend.
     - `Channel index in backend` - Starting from 1 number the channels as per the order they appear on the backend.
 * **Reminder time (minutes before programme start)**: The amount of time in minutes prior to a programme start that a reminder should pop up.
+* **Skip initial EPG load**: Ignore the initial EPG load. Enabled by default to prevent crash issues on LibreElec/CoreElec.
 
 ### Timeshift
 Settings related to the timeshift.

--- a/pvr.vbox/addon.xml.in
+++ b/pvr.vbox/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vbox"
-  version="5.4.0"
+  version="5.5.0"
   name="VBox TV Gateway PVR Client"
   provider-name="Sam Stenvall">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.vbox/changelog.txt
+++ b/pvr.vbox/changelog.txt
@@ -1,3 +1,7 @@
+5.5.0
+- Skip initial EPG load to avoid crash scenario on boot on LibreElec/CoreElec
+- New settings format and settings levels / help text
+
 5.4.0
 - Fix timezone offset changing kodi time
 - remove compat functions as no longer needed

--- a/pvr.vbox/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vbox/resources/language/resource.language.en_gb/strings.po
@@ -16,100 +16,251 @@ msgstr ""
 "Language: en_GB\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#settings labels
+###################
+# settings labels #
+###################
 
+#label-group: Connection - Local network
 msgctxt "#30000"
-msgid "Connection (internal)"
+msgid "Local network"
 msgstr ""
 
+#label: Connection - hostname
+#label: Connection - external_hostname
 msgctxt "#30001"
 msgid "Hostname or IP address"
 msgstr ""
 
+#label: Connection - http_port
+#label: Connection - external_http_port
 msgctxt "#30002"
 msgid "HTTP port"
 msgstr ""
 
+#label: Connection - upnp_port
+#label: Connection - external_upnp_port
 msgctxt "#30003"
 msgid "UPnP port"
 msgstr ""
 
+#label: Connection - connection_timeout
+#label: Connection - external_connection_timeout
 msgctxt "#30004"
-msgid "Connection timeout (seconds)"
+msgid "Connection timeout"
 msgstr ""
 
+#label: Connection - https_port
+#label: Connection - external_https_port
 msgctxt "#30005"
-msgid "HTTPS port (leave empty to use plain HTTP)"
+msgid "HTTPS port (set to 0 to use plain HTTP)"
 msgstr ""
 
-#empty strings from id 30006 to 30049
-
-msgctxt "#30050"
-msgid "Connection (external)"
+#label-category: Connection
+msgctxt "#30006"
+msgid "Connection"
 msgstr ""
 
-#empty strings from id 30051 to 30099
+#label-group: Connection - Internet
+msgctxt "#30007"
+msgid "Internet"
+msgstr ""
 
-msgctxt "#30100"
+#empty strings from id 30008 to 30019
+
+#label-category: Channel & EPG
+msgctxt "#30020"
+msgid "Channel & EPG"
+msgstr ""
+
+#label-group: Channel & EPG - Channels
+msgctxt "#30021"
+msgid "Channels"
+msgstr ""
+
+#label-group: Channel & EPG - EPG
+msgctxt "#30022"
 msgid "EPG"
 msgstr ""
 
-#empty strings from id 30101 to 30104
-
-msgctxt "#30105"
+#label: Channel & EPG - set_channelid_using_order
+msgctxt "#30023"
 msgid "Channel numbers set by"
 msgstr ""
 
+#label-option: Channel & EPG - set_channelid_using_order
+msgctxt "#30024"
+msgid "LCN (Logical Channel Number) from backend"
+msgstr ""
+
+#label-option: Channel & EPG - set_channelid_using_order
+msgctxt "#30025"
+msgid "Channel index in backend"
+msgstr ""
+
+#label: Channel & EPG - reminder_mins_before_prog
+msgctxt "#30026"
+msgid "Reminder time (minutes before program starts)"
+msgstr ""
+
+#label: Channel & EPG - skip_initial_epg_load
+msgctxt "#30027"
+msgid "Skip initial EPG load"
+msgstr ""
+
+#empty strings from id 30028 to 30039
+
+#label-category: Timeshift
+#label-group: Timeshift
+msgctxt "#30040"
+msgid "Timeshift"
+msgstr ""
+
+#label: Timeshift - timeshift_enabled
+msgctxt "#30041"
+msgid "Enable timeshifting"
+msgstr ""
+
+#label: Timeshift - timeshift_path
+msgctxt "#30042"
+msgid "Timeshift buffer path"
+msgstr ""
+
+#empty strings from id 30043 to 30105
+
+#############
+# menuhooks #
+#############
+
+#label-menuhook: MENUHOOK_ID_RESCAN_EPG - PVR_MENUHOOK_SETTING
 msgctxt "#30106"
 msgid "VBox device rescan of EPG (will take a while)"
 msgstr ""
 
+#label-menuhook: MENUHOOK_ID_SYNC_EPG - PVR_MENUHOOK_SETTING
 msgctxt "#30107"
 msgid "Sync EPG"
 msgstr ""
 
-msgctxt "#30108"
-msgid "LCN (Logical Channel Number) from backend"
-msgstr ""
+#empty strings from id 30108 to 30109
 
-msgctxt "#30109"
-msgid "Channel index in backend"
-msgstr ""
-
+#label-menuhook: MENUHOOK_ID_EPG_REMINDER - PVR_MENUHOOK_EPG
 msgctxt "#30110"
 msgid "Remind me"
 msgstr ""
 
+#label-menuhook: MENUHOOK_ID_MANUAL_REMINDER - PVR_MENUHOOK_CHANNEL
 msgctxt "#30111"
 msgid "Manual reminder"
 msgstr ""
 
+#label-menuhook: MENUHOOK_ID_CANCEL_EPG_REMINDER - PVR_MENUHOOK_EPG
 msgctxt "#30112"
 msgid "Cancel reminder (if exists)"
 msgstr ""
 
+#label-menuhook: MENUHOOK_ID_CANCEL_CHANNEL_REMINDER - PVR_MENUHOOK_CHANNEL
 msgctxt "#30113"
 msgid "Cancel all the channel's reminders"
 msgstr ""
 
-msgctxt "#30114"
-msgid "Reminder time (minutes before program starts)"
+#empty strings from id 30114 to 30599
+
+#############
+# help info #
+#############
+
+#help info - Connection
+
+#help-category: connection
+msgctxt "#30600"
+msgid "Contains settings for connecting to the VBox device from both your local network and from the internet. A local connection will be attempted first and if unsuccessful the internet settings will be used."
 msgstr ""
 
-msgctxt "#30115"
-msgid "Skip initial EPG load"
+#help: Connection - hostname
+msgctxt "#30601"
+msgid "The IP address or hostname of your VBox when accessed from the local network."
 msgstr ""
 
-#empty strings from id 30116 to 30199
-
-msgctxt "#30200"
-msgid "Timeshift"
+#help: Connection - http_port
+msgctxt "#30602"
+msgid "The port used to connect to your VBox when accessed from the local network. Default value is `80`."
 msgstr ""
 
-msgctxt "#30201"
-msgid "Enable timeshifting"
+#help: Connection - https_port
+msgctxt "#30603"
+msgid "The port used to connect to your VBox if using HTTPS when accessed from the local network. The default `0` means this is disabled and HTTP will be used instead."
 msgstr ""
 
-msgctxt "#30202"
-msgid "Timeshift buffer path"
+#help: Connection - upnp_port
+msgctxt "#30604"
+msgid "The port used to connect to your VBox via UPnP when accessed from the local network. Default value is `55555`."
+msgstr ""
+
+#help: Connection - connection_timeout
+msgctxt "#30605"
+msgid "The value used (in seconds) to denote when a connection attempt has failed when accessed from the local network. Default value is `3`."
+msgstr ""
+
+#help: Connection - external_hostname
+msgctxt "#30606"
+msgid "The IP address or hostname of your VBox when accessed from the internet."
+msgstr ""
+
+#help: Connection - external_http_port
+msgctxt "#30607"
+msgid "The port used to connect to your VBox when accessed from the internet."
+msgstr ""
+
+#help: Connection - external_https_port
+msgctxt "#30608"
+msgid "The port used to connect to your VBox if using HTTPS when accessed from the internet. The default `0` means this is disabled and HTTP will be used instead."
+msgstr ""
+
+#help: Connection - external_upnp_port
+msgctxt "#30609"
+msgid "The port used to connect to your VBox via UPnP when accessed from the internet. Default value is `55555`."
+msgstr ""
+
+#help: Connection - external_connection_timeout
+msgctxt "#30610"
+msgid "The value used (in seconds) to denote when a connection attempt has failed when accessed from the internet. Default value is `10`."
+msgstr ""
+
+#empty strings from id 30611 to 30619
+
+#help-category: Channels & EPG
+msgctxt "#30620"
+msgid "Settings related to Channels & EPG."
+msgstr ""
+
+#help: Channels & EPG - set_channelid_using_order
+msgctxt "#30621"
+msgid "Channel numbers can be set via either of the following two options: [LCN (Logical Channel Number) from backend] The channel numbers as set on the backend; [Channel index in backend] Starting from 1 number the channels as per the order they appear on the backend."
+msgstr ""
+
+#help: Channels & EPG - reminder_mins_before_prog
+msgctxt "#30622"
+msgid "The amount of time in minutes prior to a programme start that a reminder should pop up."
+msgstr ""
+
+#help: Channels & EPG - skip_initial_epg_load
+msgctxt "#30623"
+msgid "Ignore the initial EPG load. Enabled by default to prevent crash issues on LibreElec/CoreElec."
+msgstr ""
+
+#empty strings from id 30624 to 30639
+
+#help-category: Timeshift
+msgctxt "#30640"
+msgid "Settings related to the timeshift."
+msgstr ""
+
+#help: Timeshift - timeshift_enabled
+msgctxt "#30641"
+msgid "If enabled allows pause, rewind and fast-forward of live TV."
+msgstr ""
+
+#help: Timeshift - timeshift_path
+msgctxt "#30642"
+msgid "The path where the timeshift buffer files should be stored when timeshifting is enabled. Make sure you have a reasonable amount of disk space available since the buffer will grow indefinitely until you stop watching or switch channels."
 msgstr ""

--- a/pvr.vbox/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vbox/resources/language/resource.language.en_gb/strings.po
@@ -96,7 +96,11 @@ msgctxt "#30114"
 msgid "Reminder time (minutes before program starts)"
 msgstr ""
 
-#empty strings from id 30115 to 30199
+msgctxt "#30115"
+msgid "Skip initial EPG load"
+msgstr ""
+
+#empty strings from id 30116 to 30199
 
 msgctxt "#30200"
 msgid "Timeshift"

--- a/pvr.vbox/resources/settings.xml
+++ b/pvr.vbox/resources/settings.xml
@@ -1,3 +1,182 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<settings version="1">
+  <section id="pvr.vbox">
+
+    <!-- Connection -->
+    <category id="connection" label="30006" help="30600">
+      <group id="1" label="30000">
+        <setting id="hostname" type="string" label="30001" help="30601">
+          <level>0</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string" />
+        </setting>
+        <setting id="http_port" type="integer" label="30002" help="30602">
+          <level>1</level>
+          <default>80</default>
+          <constraints>
+            <minimum>1</minimum>
+            <step>1</step>
+            <maximum>65535</maximum>
+          </constraints>
+          <control type="edit" format="integer" />
+        </setting>
+        <setting id="https_port" type="integer" label="30005" help="30603">
+          <level>2</level>
+          <default>0</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>65535</maximum>
+          </constraints>
+          <control type="edit" format="integer" />
+        </setting>
+        <setting id="upnp_port" type="integer" label="30003" help="30604">
+          <level>2</level>
+          <default>55555</default>
+          <constraints>
+            <minimum>1</minimum>
+            <step>1</step>
+            <maximum>65535</maximum>
+          </constraints>
+          <control type="edit" format="integer" />
+        </setting>
+        <setting id="connection_timeout" type="integer" label="30004" help="30605">
+          <level>3</level>
+          <default>3</default>
+          <constraints>
+            <minimum>1</minimum>
+            <step>1</step>
+            <maximum>60</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>true</popup>
+            <formatlabel>14045</formatlabel>
+          </control>
+        </setting>
+      </group>
+      <group id="2" label="30007">
+        <setting id="external_hostname" type="string" label="30001" help="30606">
+          <level>2</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string" />
+        </setting>
+        <setting id="external_http_port" type="integer" label="30002" help="30607">
+          <level>2</level>
+          <default>19999</default>
+          <constraints>
+            <minimum>1</minimum>
+            <step>1</step>
+            <maximum>65535</maximum>
+          </constraints>
+          <control type="edit" format="integer" />
+        </setting>
+       <setting id="external_https_port" type="integer" label="30005" help="30608">
+          <level>2</level>
+          <default>0</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>65535</maximum>
+          </constraints>
+          <control type="edit" format="integer" />
+        </setting>
+        <setting id="external_upnp_port" type="integer" label="30003" help="30609">
+          <level>2</level>
+          <default>55555</default>
+          <constraints>
+            <minimum>1</minimum>
+            <step>1</step>
+            <maximum>65535</maximum>
+          </constraints>
+          <control type="edit" format="integer" />
+        </setting>
+        <setting id="external_connection_timeout" type="integer" label="30004" help="30610">
+          <level>3</level>
+          <default>10</default>
+          <constraints>
+            <minimum>1</minimum>
+            <step>1</step>
+            <maximum>60</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>true</popup>
+            <formatlabel>14045</formatlabel>
+          </control>
+        </setting>
+      </group>
+    </category>
+
+    <!-- Channels & EPG -->
+    <category id="epg" label="30020" help="30620">
+      <group id="1" label="30021">
+        <setting id="set_channelid_using_order" type="integer" label="30023" help="30621">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="30024">0</option> <!-- LCN -->
+              <option label="30025">1</option> <!-- BACKEND ORDER -->
+            </options>
+          </constraints>
+          <control type="list" format="integer" />
+        </setting>
+      </group>
+      <group id="2" label="30022">
+        <setting id="reminder_mins_before_prog" type="integer" label="30026" help="30622">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <minimum>1</minimum>
+            <step>1</step>
+            <maximum>30</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>true</popup>
+            <formatlabel>14044</formatlabel>
+          </control>
+        </setting>
+        <setting id="skip_initial_epg_load" type="boolean" label="30027" help="30623">
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+    </category>
+
+    <!-- Timeshift -->
+    <category id="timeshift" label="30006" help="30640">
+      <group id="1" label="30040">
+        <setting id="timeshift_enabled" type="boolean" label="30041" help="30641">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="timeshift_path" type="path" parent="timeshift_enabled" label="30042" help="30642">
+          <level>2</level>
+          <default>special://userdata/addon_data/pvr.vbox</default>
+          <constraints>
+            <allowempty>true</allowempty>
+            <writable>true</writable>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="timeshift_enabled" operator="is">true</dependency>
+          </dependencies>
+          <control type="button" format="path">
+            <heading>657</heading>
+          </control>
+        </setting>
+      </group>
+    </category>
+  </section>
+</settings>
+
+<!--
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
   <category label="30000">
@@ -27,3 +206,4 @@
     <setting id="timeshift_path" type="folder" label="30202" default="special://userdata/addon_data/pvr.vbox" option="writeable" enable="eq(-1,true)" />
   </category>
 </settings>
+-->

--- a/pvr.vbox/resources/settings.xml
+++ b/pvr.vbox/resources/settings.xml
@@ -19,6 +19,7 @@
   <category label="30100">
     <setting id="set_channelid_using_order" type="enum" label="30105" lvalues="30108|30109" default="0"/>
     <setting id="reminder_mins_before_prog" type="number" option="int" label="30114" default="0"/>
+    <setting id="skip_initial_epg_load" type="bool" label="30115" default="true" />
   </category>
 
   <category label="30200">

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -42,6 +42,7 @@ CHelper_libKODI_guilib  *GUI = NULL;
 // Initialize globals
 ADDON_STATUS   g_status = ADDON_STATUS_UNKNOWN;
 VBox *g_vbox = nullptr;
+bool g_skippingInitialEpgLoad;
 timeshift::Buffer *g_timeshiftBuffer = nullptr;
 RecordingReader* recordingReader = nullptr;
 
@@ -58,6 +59,7 @@ int g_externalConnectionTimeout;
 
 ChannelOrder g_setChannelIdUsingOrder;
 unsigned int g_remindMinsBeforeProg;
+bool g_skipInitialEpgLoad;
 bool g_timeshiftEnabled;
 std::string g_timeshiftBufferPath;
 
@@ -99,6 +101,7 @@ void ADDON_ReadSettings()
   UPDATE_INT(g_externalConnectionTimeout, "external_connection_timeout", 10);
   UPDATE_INT(g_setChannelIdUsingOrder, "set_channelid_using_order", CH_ORDER_BY_LCN);
   UPDATE_INT(g_remindMinsBeforeProg, "reminder_mins_before_prog", 0);
+  UPDATE_INT(g_skipInitialEpgLoad, "skip_initial_epg_load", true);
   UPDATE_INT(g_timeshiftEnabled, "timeshift_enabled", false);
   UPDATE_STR(g_timeshiftBufferPath, "timeshift_path", buffer, "");
 
@@ -151,6 +154,7 @@ ADDON_STATUS ADDON_Create(void* hdl, void* props)
 
   settings.m_setChannelIdUsingOrder = g_setChannelIdUsingOrder;
   settings.m_remindMinsBeforeProg = g_remindMinsBeforeProg;
+  settings.m_skipInitialEpgLoad = g_skipInitialEpgLoad;
   settings.m_timeshiftEnabled = g_timeshiftEnabled;
   settings.m_timeshiftBufferPath = g_timeshiftBufferPath;
 
@@ -174,7 +178,9 @@ ADDON_STATUS ADDON_Create(void* hdl, void* props)
       g_vbox->OnGuideUpdated = []()
       {
         for (const auto &channel : g_vbox->GetChannels())
+        {
           PVR->TriggerEpgUpdate(ContentIdentifier::GetUniqueId(channel));
+        }
       };
 
       // Create the timeshift buffer
@@ -263,6 +269,7 @@ ADDON_STATUS ADDON_SetSetting(const char *settingName, const void *settingValue)
   UPDATE_INT("external_connection_timeout", int, settings.m_externalConnectionParams.timeout);
   UPDATE_INT("set_channelid_using_order", ChannelOrder, settings.m_setChannelIdUsingOrder);
   UPDATE_INT("reminder_mins_before_prog", unsigned int, settings.m_remindMinsBeforeProg)
+  UPDATE_INT("skip_initial_epg_load", bool, settings.m_skipInitialEpgLoad);
   UPDATE_INT("timeshift_enabled", bool, settings.m_timeshiftEnabled);
   UPDATE_STR("timeshift_path", settings.m_timeshiftBufferPath);
 
@@ -881,6 +888,13 @@ PVR_ERROR GetEPGForChannel(ADDON_HANDLE handle, int iChannelUid, time_t iStart, 
 
   if (!channelPtr)
     return PVR_ERROR_INVALID_PARAMETERS;
+
+  if (g_skippingInitialEpgLoad)
+  {
+    VBox::Log(LOG_DEBUG, "%s Skipping Initial EPG for channel: %s", __FUNCTION__, channelPtr->m_name.c_str());
+    g_vbox->MarkChannelAsInitialEpgSkipped(iChannelUid);
+    return PVR_ERROR_NO_ERROR;
+  }
 
   // Retrieve the schedule
   const auto schedule = g_vbox->GetSchedule(channelPtr);

--- a/src/client.h
+++ b/src/client.h
@@ -37,3 +37,4 @@ extern CHelper_libKODI_guilib       *GUI;
 // Globals
 extern ADDON_STATUS g_status;
 extern vbox::VBox *g_vbox;
+extern bool g_skippingInitialEpgLoad;

--- a/src/vbox/Settings.h
+++ b/src/vbox/Settings.h
@@ -89,6 +89,7 @@ namespace vbox {
     ConnectionParameters m_externalConnectionParams;
     ChannelOrder m_setChannelIdUsingOrder;
     unsigned int m_remindMinsBeforeProg;
+    bool m_skipInitialEpgLoad;
     bool m_timeshiftEnabled;
     std::string m_timeshiftBufferPath;
   };

--- a/src/vbox/VBox.cpp
+++ b/src/vbox/VBox.cpp
@@ -133,6 +133,15 @@ void VBox::Initialize()
   // Consider the addon initialized
   m_stateHandler.EnterState(StartupState::INITIALIZED);
 
+  g_skippingInitialEpgLoad = m_settings.m_skipInitialEpgLoad;
+
+  RetrieveChannels(false);
+  {
+    std::unique_lock<std::mutex> lock(m_mutex);
+    for (auto channel : m_channels)
+      m_unskippedInitialEpgChannelsMap.insert({channel->m_uniqueId, channel->m_uniqueId});
+  }
+
   // Start the background updater thread
   m_active = true;
   m_backgroundThread = std::thread([this]()
@@ -275,6 +284,22 @@ void VBox::BackgroundUpdater()
   RetrieveRecordings(false);
   RetrieveGuide(false);
 
+  // Wait for the initial EPG update to complete
+  int totalWaitSecs = 0;
+  while (m_active && totalWaitSecs < INITIAL_EPG_WAIT_SECS)
+  {
+    totalWaitSecs += INITIAL_EPG_STEP_SECS;
+
+    if (!IsInitialEpgSkippingCompleted())
+      std::this_thread::sleep_for(std::chrono::milliseconds(INITIAL_EPG_STEP_SECS * 1000));
+  }
+
+  g_skippingInitialEpgLoad = false;
+
+  // Whether or not initial EPG updates occurred now Trigger "Real" EPG updates
+  // This will regard Initial EPG as completed anyway.
+  TriggerEpgUpdatesForChannels();
+
   while (m_active)
   {
     // check for reminders each iteration
@@ -309,6 +334,36 @@ void VBox::BackgroundUpdater()
     lapCounter++;
     usleep(5000 * 1000); // for some infinitely retarded reason, std::thread::sleep_for doesn't work
   }
+}
+
+bool VBox::IsInitialEpgSkippingCompleted()
+{
+  Log(LOG_DEBUG, "%s Waiting to Get Initial EPG for %d remaining channels", __FUNCTION__, m_unskippedInitialEpgChannelsMap.size());
+
+  return m_unskippedInitialEpgChannelsMap.size() == 0;
+}
+
+void VBox::TriggerEpgUpdatesForChannels()
+{
+  {
+    std::unique_lock<std::mutex> lock(m_mutex);
+    for (auto& channel : m_channels)
+    {
+      //We want to trigger full updates only so let's make sure it's not an initialEpg
+      m_unskippedInitialEpgChannelsMap.erase(channel->m_uniqueId);
+
+      Log(LOG_DEBUG, "%s - Trigger EPG update for channel: %s (%s)", __FUNCTION__, channel->m_name.c_str(), channel->m_uniqueId.c_str());
+    }
+  }
+
+  OnGuideUpdated();
+}
+
+void VBox::MarkChannelAsInitialEpgSkipped(unsigned int channelUid)
+{
+  const ChannelPtr channelPtr = g_vbox->GetChannel(channelUid);
+
+  m_unskippedInitialEpgChannelsMap.erase(channelPtr->m_uniqueId);
 }
 
 bool VBox::ValidateSettings() const

--- a/src/vbox/VBox.h
+++ b/src/vbox/VBox.h
@@ -22,6 +22,7 @@
 
 #include <string>
 #include <vector>
+#include <map>
 #include <mutex>
 #include <thread>
 #include <atomic>
@@ -201,6 +202,9 @@ namespace vbox {
     int GetCategoriesGenreType(std::vector<std::string> &categories) const;
     void StartEPGScan();
     void SyncEPGNow();
+    void TriggerEpgUpdatesForChannels();
+    bool IsInitialEpgSkippingCompleted();
+    void MarkChannelAsInitialEpgSkipped(unsigned int channelUid);
 
     // Reminder methods
     bool AddReminder(const ChannelPtr &channel, const ::xmltv::ProgrammePtr &programme);
@@ -220,6 +224,8 @@ namespace vbox {
     std::function<void()> OnGuideUpdated;
 
   private:
+    static const int INITIAL_EPG_WAIT_SECS = 60;
+    static const int INITIAL_EPG_STEP_SECS = 5;
 
     void BackgroundUpdater();
     unsigned int GetDBVersion(std::string &versionName) const;
@@ -342,6 +348,11 @@ namespace vbox {
      * channel is playing
      */
     ChannelPtr m_currentChannel;
+
+    /**
+     * Map of channels to be skipped on inital EPG load
+     */
+    std::map<std::string, std::string> m_unskippedInitialEpgChannelsMap;
 
     /**
      * Mutex for protecting access to m_channels and m_recordings


### PR DESCRIPTION
5.5.0
- Skip initial EPG load to avoid crash scenario on boot on LibreElec/CoreElec
- New settings format and settings levels / help text

Same solution is used in pvr,vuplus. The issue is that an EPG load is generated by kodi and also the the addon. These appear to conflict and 2 channels call GetEPGForChannel at the same time. This happens occasionally some hard to capture.