### PR TITLE
Remove p8 from debian control file - v7.0.3

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: kodi-pvr-vbox
 Priority: extra
 Maintainer: Sam Stenvall <sam.stenvall@kodi.tv>
 Build-Depends: debhelper (>= 9.0.0), cmake,
-               libp8-platform-dev, kodi-addon-dev
+               kodi-addon-dev
 Standards-Version: 4.1.2
 Section: libs
 Homepage: https://github.com/kodi-pvr/pvr.vbox

--- a/pvr.vbox/addon.xml.in
+++ b/pvr.vbox/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vbox"
-  version="7.0.2"
+  version="7.0.3"
   name="VBox TV Gateway PVR Client"
   provider-name="Sam Stenvall">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.vbox/changelog.txt
+++ b/pvr.vbox/changelog.txt
@@ -1,3 +1,6 @@
+7.0.3
+- Remove p8 from debian control file
+
 7.0.2
 - Use kodi add-on StringUtils instead of local copy
 


### PR DESCRIPTION
7.0.3
- Remove p8 from debian control file
