### PR TITLE
Update sync-addon-metadata-translations.yml

### DIFF
--- a/.github/workflows/sync-addon-metadata-translations.yml
+++ b/.github/workflows/sync-addon-metadata-translations.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ Matrix, Nexus ]
     paths:
-      - '**addon.xml'
+      - '**addon.xml.in'
       - '**resource.language.**strings.po'
 
 jobs:


### PR DESCRIPTION
This updates the metadata sync workflow to look for `addon.xml.in` instead of `addon.xml`.