### PR TITLE
[Matrix/Nexus] copyright year increase and cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,61 @@
+name: Build and run tests
+on: [push, pull_request]
+env:
+  app_id: pvr.vbox
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - name: "Debian package test"
+          os: ubuntu-18.04
+          CC: gcc
+          CXX: g++
+          DEBIAN_BUILD: true
+        #- os: ubuntu-18.04
+          #CC: gcc
+          #CXX: g++
+        #- os: ubuntu-18.04
+          #CC: clang
+          #CXX: clang++
+        #- os: macos-10.15
+    steps:
+    - name: Install needed ubuntu depends
+      env:
+        DEBIAN_BUILD: ${{ matrix.DEBIAN_BUILD }}
+      run: |
+        if [[ $DEBIAN_BUILD == true ]]; then sudo add-apt-repository -y ppa:team-xbmc/xbmc-nightly; fi
+        if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get update; fi
+        if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get install fakeroot; fi
+    - name: Checkout Kodi repo
+      uses: actions/checkout@v2
+      with:
+        repository: xbmc/xbmc
+        ref: master
+        path: xbmc
+    - name: Checkout pvr.vbox repo
+      uses: actions/checkout@v2
+      with:
+        path: ${{ env.app_id }}
+    - name: Configure
+      env:
+        CC: ${{ matrix.CC }}
+        CXX: ${{ matrix.CXX }}
+        DEBIAN_BUILD: ${{ matrix.DEBIAN_BUILD }}
+      run: |
+        if [[ $DEBIAN_BUILD != true ]]; then cd ${app_id} && mkdir -p build && cd build; fi
+        if [[ $DEBIAN_BUILD != true ]]; then cmake -DADDONS_TO_BUILD=${app_id} -DADDON_SRC_PREFIX=${{ github.workspace }} -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/xbmc/addons -DPACKAGE_ZIP=1 ${{ github.workspace }}/xbmc/cmake/addons; fi
+        if [[ $DEBIAN_BUILD == true ]]; then wget https://raw.githubusercontent.com/xbmc/xbmc/master/xbmc/addons/kodi-dev-kit/tools/debian-addon-package-test.sh && chmod +x ./debian-addon-package-test.sh; fi
+        if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get build-dep ${{ github.workspace }}/${app_id}; fi
+    - name: Build
+      env:
+        CC: ${{ matrix.CC }}
+        CXX: ${{ matrix.CXX }}
+        DEBIAN_BUILD: ${{ matrix.DEBIAN_BUILD }}
+      run: |
+        if [[ $DEBIAN_BUILD != true ]]; then cd ${app_id}/build; fi
+        if [[ $DEBIAN_BUILD != true ]]; then make; fi
+        if [[ $DEBIAN_BUILD == true ]]; then ./debian-addon-package-test.sh ${{ github.workspace }}/${app_id}; fi

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
+[![Build and run tests](https://github.com/kodi-pvr/pvr.vbox/actions/workflows/build.yml/badge.svg?branch=Matrix)](https://github.com/kodi-pvr/pvr.vbox/actions/workflows/build.yml)
 [![Build Status](https://travis-ci.org/kodi-pvr/pvr.vbox.svg?branch=Matrix)](https://travis-ci.org/kodi-pvr/pvr.vbox/branches)
 [![Build Status](https://dev.azure.com/teamkodi/kodi-pvr/_apis/build/status/kodi-pvr.pvr.vbox?branchName=Matrix)](https://dev.azure.com/teamkodi/kodi-pvr/_build/latest?definitionId=70&branchName=Matrix)
 [![Build Status](https://jenkins.kodi.tv/view/Addons/job/kodi-pvr/job/pvr.vbox/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/kodi-pvr%2Fpvr.vbox/branches/)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
 [![Build and run tests](https://github.com/kodi-pvr/pvr.vbox/actions/workflows/build.yml/badge.svg?branch=Matrix)](https://github.com/kodi-pvr/pvr.vbox/actions/workflows/build.yml)
-[![Build Status](https://travis-ci.org/kodi-pvr/pvr.vbox.svg?branch=Matrix)](https://travis-ci.org/kodi-pvr/pvr.vbox/branches)
 [![Build Status](https://dev.azure.com/teamkodi/kodi-pvr/_apis/build/status/kodi-pvr.pvr.vbox?branchName=Matrix)](https://dev.azure.com/teamkodi/kodi-pvr/_build/latest?definitionId=70&branchName=Matrix)
 [![Build Status](https://jenkins.kodi.tv/view/Addons/job/kodi-pvr/job/pvr.vbox/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/kodi-pvr%2Fpvr.vbox/branches/)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/5120/badge.svg)](https://scan.coverity.com/projects/5120)

--- a/debian/copyright
+++ b/debian/copyright
@@ -3,7 +3,7 @@ Upstream-Name: pvr.vbox
 Source: https://github.com/kodi-pvr/pvr.vbox
 
 Files: *
-Copyright: 2015-2020 Team Kodi
+Copyright: 2015-2021 Team Kodi
            2015 Sam Stenvall
 License: GPL-2+
  This package is free software; you can redistribute it and/or modify
@@ -24,7 +24,7 @@ License: GPL-2+
 
 
 Files: debian/*
-Copyright: 2020 Team Kodi
+Copyright: 2020-2021 Team Kodi
            2013 Arne Morten Kvarving <arne.morten.kvarving@sintef.no>
            2013 wsnipex <wsnipex@a1.net>
 License: GPL-2+

--- a/debian/rules
+++ b/debian/rules
@@ -10,13 +10,10 @@
 #export DH_VERBOSE=1
 
 %:
-	dh $@ 
+	dh $@
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1 -DUSE_LTO=1
-
-override_dh_strip:
-	dh_strip -pkodi-pvr-vbox --dbg-package=kodi-pvr-vbox-dbg
+	dh_auto_configure -- -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=1 -DUSE_LTO=1
 
 override_dh_installdocs:
 	dh_installdocs --link-doc=kodi-pvr-vbox

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (quilt)
+3.0 (native)

--- a/src/VBoxInstance.cpp
+++ b/src/VBoxInstance.cpp
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/VBoxInstance.h
+++ b/src/VBoxInstance.h
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/addon.h
+++ b/src/addon.h
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/timeshift/Buffer.cpp
+++ b/src/timeshift/Buffer.cpp
@@ -1,23 +1,10 @@
 /*
-*      Copyright (C) 2015 Sam Stenvall
-*
-*  This Program is free software; you can redistribute it and/or modify
-*  it under the terms of the GNU General Public License as published by
-*  the Free Software Foundation; either version 2, or (at your option)
-*  any later version.
-*
-*  This Program is distributed in the hope that it will be useful,
-*  but WITHOUT ANY WARRANTY; without even the implied warranty of
-*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-*  GNU General Public License for more details.
-*
-*  You should have received a copy of the GNU General Public License
-*  along with XBMC; see the file COPYING.  If not, write to
-*  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
-*  MA 02110-1301  USA
-*  http://www.gnu.org/copyleft/gpl.html
-*
-*/
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
+ *  Copyright (C) 2015 Sam Stenvall
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
 
 #include "Buffer.h"
 

--- a/src/timeshift/Buffer.h
+++ b/src/timeshift/Buffer.h
@@ -1,24 +1,12 @@
-#pragma once
 /*
-*      Copyright (C) 2015 Sam Stenvall
-*
-*  This Program is free software; you can redistribute it and/or modify
-*  it under the terms of the GNU General Public License as published by
-*  the Free Software Foundation; either version 2, or (at your option)
-*  any later version.
-*
-*  This Program is distributed in the hope that it will be useful,
-*  but WITHOUT ANY WARRANTY; without even the implied warranty of
-*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-*  GNU General Public License for more details.
-*
-*  You should have received a copy of the GNU General Public License
-*  along with XBMC; see the file COPYING.  If not, write to
-*  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
-*  MA 02110-1301  USA
-*  http://www.gnu.org/copyleft/gpl.html
-*
-*/
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
+ *  Copyright (C) 2015 Sam Stenvall
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#pragma once
 
 #include <ctime>
 #include <string>

--- a/src/timeshift/DummyBuffer.cpp
+++ b/src/timeshift/DummyBuffer.cpp
@@ -1,23 +1,10 @@
 /*
-*      Copyright (C) 2015 Sam Stenvall
-*
-*  This Program is free software; you can redistribute it and/or modify
-*  it under the terms of the GNU General Public License as published by
-*  the Free Software Foundation; either version 2, or (at your option)
-*  any later version.
-*
-*  This Program is distributed in the hope that it will be useful,
-*  but WITHOUT ANY WARRANTY; without even the implied warranty of
-*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-*  GNU General Public License for more details.
-*
-*  You should have received a copy of the GNU General Public License
-*  along with XBMC; see the file COPYING.  If not, write to
-*  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
-*  MA 02110-1301  USA
-*  http://www.gnu.org/copyleft/gpl.html
-*
-*/
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
+ *  Copyright (C) 2015 Sam Stenvall
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
 
 #include "DummyBuffer.h"
 

--- a/src/timeshift/DummyBuffer.h
+++ b/src/timeshift/DummyBuffer.h
@@ -1,24 +1,12 @@
-#pragma once
 /*
-*      Copyright (C) 2015 Sam Stenvall
-*
-*  This Program is free software; you can redistribute it and/or modify
-*  it under the terms of the GNU General Public License as published by
-*  the Free Software Foundation; either version 2, or (at your option)
-*  any later version.
-*
-*  This Program is distributed in the hope that it will be useful,
-*  but WITHOUT ANY WARRANTY; without even the implied warranty of
-*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-*  GNU General Public License for more details.
-*
-*  You should have received a copy of the GNU General Public License
-*  along with XBMC; see the file COPYING.  If not, write to
-*  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
-*  MA 02110-1301  USA
-*  http://www.gnu.org/copyleft/gpl.html
-*
-*/
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
+ *  Copyright (C) 2015 Sam Stenvall
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#pragma once
 
 #include "Buffer.h"
 

--- a/src/timeshift/FilesystemBuffer.cpp
+++ b/src/timeshift/FilesystemBuffer.cpp
@@ -1,23 +1,10 @@
 /*
-*      Copyright (C) 2015 Sam Stenvall
-*
-*  This Program is free software; you can redistribute it and/or modify
-*  it under the terms of the GNU General Public License as published by
-*  the Free Software Foundation; either version 2, or (at your option)
-*  any later version.
-*
-*  This Program is distributed in the hope that it will be useful,
-*  but WITHOUT ANY WARRANTY; without even the implied warranty of
-*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-*  GNU General Public License for more details.
-*
-*  You should have received a copy of the GNU General Public License
-*  along with XBMC; see the file COPYING.  If not, write to
-*  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
-*  MA 02110-1301  USA
-*  http://www.gnu.org/copyleft/gpl.html
-*
-*/
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
+ *  Copyright (C) 2015 Sam Stenvall
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
 
 #include "FilesystemBuffer.h"
 

--- a/src/timeshift/FilesystemBuffer.h
+++ b/src/timeshift/FilesystemBuffer.h
@@ -1,24 +1,12 @@
-#pragma once
 /*
-*      Copyright (C) 2015 Sam Stenvall
-*
-*  This Program is free software; you can redistribute it and/or modify
-*  it under the terms of the GNU General Public License as published by
-*  the Free Software Foundation; either version 2, or (at your option)
-*  any later version.
-*
-*  This Program is distributed in the hope that it will be useful,
-*  but WITHOUT ANY WARRANTY; without even the implied warranty of
-*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-*  GNU General Public License for more details.
-*
-*  You should have received a copy of the GNU General Public License
-*  along with XBMC; see the file COPYING.  If not, write to
-*  the Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
-*  MA 02110-1301  USA
-*  http://www.gnu.org/copyleft/gpl.html
-*
-*/
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
+ *  Copyright (C) 2015 Sam Stenvall
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#pragma once
 
 #include "Buffer.h"
 

--- a/src/vbox/CategoryGenreMapper.cpp
+++ b/src/vbox/CategoryGenreMapper.cpp
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/CategoryGenreMapper.h
+++ b/src/vbox/CategoryGenreMapper.h
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/Channel.h
+++ b/src/vbox/Channel.h
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/ChannelStreamingStatus.cpp
+++ b/src/vbox/ChannelStreamingStatus.cpp
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/ChannelStreamingStatus.h
+++ b/src/vbox/ChannelStreamingStatus.h
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/ContentIdentifier.h
+++ b/src/vbox/ContentIdentifier.h
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/Exceptions.h
+++ b/src/vbox/Exceptions.h
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/GuideChannelMapper.cpp
+++ b/src/vbox/GuideChannelMapper.cpp
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/GuideChannelMapper.h
+++ b/src/vbox/GuideChannelMapper.h
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/Recording.cpp
+++ b/src/vbox/Recording.cpp
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/Recording.h
+++ b/src/vbox/Recording.h
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/RecordingReader.cpp
+++ b/src/vbox/RecordingReader.cpp
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/RecordingReader.h
+++ b/src/vbox/RecordingReader.h
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/SeriesRecording.cpp
+++ b/src/vbox/SeriesRecording.cpp
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/SeriesRecording.h
+++ b/src/vbox/SeriesRecording.h
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/Settings.h
+++ b/src/vbox/Settings.h
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/SoftwareVersion.cpp
+++ b/src/vbox/SoftwareVersion.cpp
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/SoftwareVersion.h
+++ b/src/vbox/SoftwareVersion.h
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/StartupStateHandler.cpp
+++ b/src/vbox/StartupStateHandler.cpp
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/StartupStateHandler.h
+++ b/src/vbox/StartupStateHandler.h
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/Utilities.h
+++ b/src/vbox/Utilities.h
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/VBox.cpp
+++ b/src/vbox/VBox.cpp
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/VBox.h
+++ b/src/vbox/VBox.h
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/request/ApiRequest.cpp
+++ b/src/vbox/request/ApiRequest.cpp
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/request/ApiRequest.h
+++ b/src/vbox/request/ApiRequest.h
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/request/FileRequest.h
+++ b/src/vbox/request/FileRequest.h
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/request/Request.h
+++ b/src/vbox/request/Request.h
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/response/Content.cpp
+++ b/src/vbox/response/Content.cpp
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/response/Content.h
+++ b/src/vbox/response/Content.h
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/response/Factory.h
+++ b/src/vbox/response/Factory.h
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/response/Response.cpp
+++ b/src/vbox/response/Response.cpp
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/vbox/response/Response.h
+++ b/src/vbox/response/Response.h
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/xmltv/Channel.cpp
+++ b/src/xmltv/Channel.cpp
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/xmltv/Channel.h
+++ b/src/xmltv/Channel.h
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/xmltv/Guide.cpp
+++ b/src/xmltv/Guide.cpp
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/xmltv/Guide.h
+++ b/src/xmltv/Guide.h
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/xmltv/Programme.cpp
+++ b/src/xmltv/Programme.cpp
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/xmltv/Programme.h
+++ b/src/xmltv/Programme.h
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/xmltv/Schedule.cpp
+++ b/src/xmltv/Schedule.cpp
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/xmltv/Schedule.h
+++ b/src/xmltv/Schedule.h
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/xmltv/Utilities.cpp
+++ b/src/xmltv/Utilities.cpp
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/xmltv/Utilities.h
+++ b/src/xmltv/Utilities.h
@@ -1,7 +1,6 @@
 /*
- *  Copyright (C) 2015-2020 Team Kodi
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) 2015 Sam Stenvall
- *  https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.


### PR DESCRIPTION
Like on all others addon requests from me, short before the new Nexus branch comes a update where then on both versions.