### PR TITLE
[Nexus] Add supports recordings delete capability for PVR API 8.0.0

### DIFF
--- a/pvr.vbox/addon.xml.in
+++ b/pvr.vbox/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vbox"
-  version="20.0.0"
+  version="20.1.0"
   name="VBox TV Gateway PVR Client"
   provider-name="Sam Stenvall">
   <requires>@ADDON_DEPENDS@</requires>
@@ -17,6 +17,9 @@
       <icon>icon.png</icon>
     </assets>
     <news>
+v20.1.0
+- Kodi PVR API to 8.0.0
+
 v20.0.0
 - Changed test builds to 'Kodi 20 Nexus'
 - Increased version to 20.0.0

--- a/pvr.vbox/changelog.txt
+++ b/pvr.vbox/changelog.txt
@@ -1,3 +1,6 @@
+v20.1.0
+- Kodi PVR API to 8.0.0
+
 v20.0.0
 - Changed test builds to 'Kodi 20 Nexus'
 - Increased version to 20.0.0

--- a/src/VBoxInstance.cpp
+++ b/src/VBoxInstance.cpp
@@ -120,6 +120,7 @@ PVR_ERROR CVBoxInstance::GetCapabilities(kodi::addon::PVRCapabilities& capabilit
   if (VBox::GetStateHandler().WaitForState(StartupState::INITIALIZED) && VBox::SupportsRecordings())
   {
     capabilities.SetSupportsRecordings(true);
+    capabilities.SetSupportsRecordingsDelete(true);
     capabilities.SetSupportsTimers(true);
   }
 


### PR DESCRIPTION
- Kodi API to 8.0.0
  - Following in API change (not all affect addon):
    - Add supports recordings delete capability
    - Add support for PVR Providers and parental rating code for EPG
    - Enforce EDL limits

This PR should be rebuilt via Jenkins after these xbmc PRs are merged:
- https://github.com/xbmc/xbmc/pull/20009
- https://github.com/xbmc/xbmc/pull/19395